### PR TITLE
Save text in modal forms and add focus after opening

### DIFF
--- a/app/assets/javascripts/common.js.coffee
+++ b/app/assets/javascripts/common.js.coffee
@@ -69,10 +69,11 @@ $(document).on 'click', '.remove_fields', (event) ->
 
 $(document).on 'shown', '#modal_form', ->
   $('html,body').css('overflow', 'hidden');
+  $('#modal_form textarea').focus();
 
 $(document).on 'hidden', '#modal_form', ->
   $('html,body').css 'overflow', 'auto'
-  $('#modal_form').remove()
+  $('#modal_form').hide()
   $('.product_selector.active').removeClass('active')
   $('.product_select_button.active').removeClass('active')
 

--- a/app/controllers/device_notes_controller.rb
+++ b/app/controllers/device_notes_controller.rb
@@ -6,6 +6,7 @@ class DeviceNotesController < ApplicationController
     @service_job = find_service_job
     @device_notes = @service_job.device_notes.newest_first
     @device_note = @service_job.device_notes.build(user_id: current_user.id)
+    @modal = 'device-notes'
     respond_to do |format|
       format.js { render 'shared/show_modal_form' }
     end

--- a/app/controllers/service_jobs_controller.rb
+++ b/app/controllers/service_jobs_controller.rb
@@ -119,6 +119,7 @@ class ServiceJobsController < ApplicationController
 
   def edit
     @service_job = find_record ServiceJob.includes(:device_notes)
+    @modal = 'service-job'
     build_device_note
     log_viewing
     respond_to do |format|

--- a/app/views/shared/show_modal_form.js.erb
+++ b/app/views/shared/show_modal_form.js.erb
@@ -1,8 +1,16 @@
-if($('#modal_form').length == 0) {
+var modalName = "<%= @modal if defined? @modal %>";
+
+if ($('#modal_form').length == 0) {
   $("body").append("<%= j(render('shared/modal_form')) %>");
 } else {
-  $("#modal_form").html("<%= j(render(params[:form_name] || 'modal_form_content')) %>");
+  var existingModalName = $("#modal_form").data("modalName");
+  if (!modalName || modalName !== existingModalName) {
+    $("#modal_form").html("<%= j(render(params[:form_name] || 'modal_form_content')) %>");
+  }
 }
+
+if (modalName) $("#modal_form").data("modalName", modalName);
 $("#modal_form:hidden").modal('show');
+
 $("a[rel~=popover], .has-popover").popover();
 $("a[rel~=tooltip], .has-tooltip").tooltip();


### PR DESCRIPTION
Changes made
-- Text is saved in the same modals on the main page
-- Focus is set on textarea element when modal is opened