### PR TITLE
fix: close gaps for repair_status='waiting' assignment

### DIFF
--- a/app/models/service_job.rb
+++ b/app/models/service_job.rb
@@ -133,6 +133,7 @@ class ServiceJob < ApplicationRecord
   after_update :clear_subscriptions_if_done_or_archived
   after_update :close_warranty_overstay_notifications_if_archived
   after_update :schedule_location_overstay_checks
+  after_create :auto_set_waiting_repair_status
   after_update :auto_set_waiting_repair_status
 
   audited
@@ -662,9 +663,16 @@ kind: 'device_return', content: id.to_s)
   end
 
   def auto_set_waiting_repair_status
-    return unless saved_change_to_location_id?
     return unless location&.is_any_repair?
     return if repair_status&.waiting?
+
+    if repair_status_id.nil?
+      # первая инициализация: новая работа, перенос со статусом nil, забытая работа на repair
+    elsif saved_change_to_location_id? && repair_status&.completed?
+      # повторный ремонт: устройство было completed, вернулось на repair — снова waiting
+    else
+      return
+    end
 
     change_repair_status!(
       RepairStatus.by_code(RepairStatus::WAITING),

--- a/db/data/20260513163858_backfill_repair_status_for_waiting_jobs.rb
+++ b/db/data/20260513163858_backfill_repair_status_for_waiting_jobs.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class BackfillRepairStatusForWaitingJobs < ActiveRecord::Migration[5.1]
+  def up
+    waiting = RepairStatus.find_by!(code: 'waiting')
+    now = Time.zone.now
+
+    repair_location_ids = Location.where("code LIKE ?", "repair%").pluck(:id)
+    scope = ServiceJob.where(repair_status_id: nil, location_id: repair_location_ids)
+
+    say_with_time "Backfilling repair_status='waiting' for #{scope.count} ServiceJobs" do
+      scope.find_each do |sj|
+        ServiceJob.transaction do
+          RepairStatusChange.create!(
+            service_job: sj,
+            from_status_id: nil,
+            to_status: waiting,
+            user_id: nil,
+            changed_at: now
+          )
+          sj.update_columns(
+            repair_status_id: waiting.id,
+            repair_status_changed_at: now,
+            updated_at: now
+          )
+        end
+      end
+    end
+  end
+
+  def down
+    say "Backfill is one-way; no rollback (would not know which markers were created by this migration)."
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20260512195814)
+DataMigrate::Data.define(version: 20260513163858)


### PR DESCRIPTION
- callback auto_set_waiting_repair_status now also runs on after_create — previously a job created directly on a repair location would never get a status
- callback no longer requires saved_change_to_location_id?: any save on a repair-location job without a status will set it to waiting (covers "forgotten" legacy jobs touched after the feature is deployed)
- guards added so the callback never overwrites in_progress / paused / completed on routine saves; only flips completed back to waiting when the device explicitly returns to a repair location (repeat repair scenario)
- data migration backfills repair_status='waiting' for all service_jobs currently sitting on a repair-* location with null status; also writes nil→waiting rows into repair_status_changes for history consistency