### PR TITLE
fix: telegram links — use SERVER_HOST instead of APP_HOST

### DIFF
--- a/app/services/repair_attention_notifier.rb
+++ b/app/services/repair_attention_notifier.rb
@@ -73,7 +73,9 @@ class RepairAttentionNotifier
   end
 
   def app_host
-    ENV.fetch('APP_HOST', 'localhost:3000')
+    ENV['SERVER_HOST'].presence ||
+      Rails.application.routes.default_url_options[:host].presence ||
+      'localhost:3000'
   end
 
   def url_helpers


### PR DESCRIPTION
The previous fallback host 'localhost:3000' was being injected into <a href="..."> URLs when APP_HOST wasn't set on the prod server. Telegram's HTML parser appears to reject messages with URLs pointing at non-public hosts and falls back to rendering the whole text as plain text — which is what users were seeing.

- RepairAttentionNotifier#app_host now reads SERVER_HOST first (the same ENV var that production.rb and staging.rb use for Rails.application.routes.default_url_options[:host])
- falls back to default_url_options[:host] if SERVER_HOST is blank, then to 'localhost:3000' as a last resort for dev/test
- this is symmetric with how all other URL-generating code in the project resolves its host