### PR TITLE
fix: sync repair_status when device task closes off repair location

### DIFF
--- a/app/models/device_task.rb
+++ b/app/models/device_task.rb
@@ -184,7 +184,7 @@ class DeviceTask < ApplicationRecord
   def sync_service_job_repair_status
     return unless is_repair?
     return unless saved_change_to_done?
-    return unless service_job&.location&.is_any_repair?
+    return if service_job&.repair_status_id.nil?
 
     if done.zero?
       revert_to_in_progress_if_completed


### PR DESCRIPTION
The sync_service_job_repair_status callback bailed out when service_job.location was no longer a repair location. But the operation that closes a device task in the UI also moves the service_job to a non-repair location in the same transaction (e.g. handing the device back to the client). The after_commit callback ran after the location change, skipped the sync, and the repair_status stayed in_progress — blocking the technician from taking the next repair via the "one active in_progress" constraint. Condition is now based on repair_status_id presence, which captures the intent ("the job is in the repair status system") regardless of current location.