### PR TITLE
feat: finalize user shift 10 min after schedule end

### DIFF
--- a/app/jobs/bootstrap_today_finalizations_job.rb
+++ b/app/jobs/bootstrap_today_finalizations_job.rb
@@ -1,0 +1,33 @@
+class BootstrapTodayFinalizationsJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    City.find_each do |city|
+      tz = city.time_zone.presence || 'Vladivostok'
+
+      Time.use_zone(tz) do
+        today = Time.zone.today
+
+        entries = ScheduleEntry
+                  .joins(:occupation_type, :schedule_group)
+                  .where(date: today)
+                  .where(schedule_groups: { city_id: city.id })
+                  .where(occupation_types: { counts_as_working: true })
+
+        entries.find_each do |entry|
+          end_seconds = entry.effective_end_seconds
+          next unless end_seconds
+
+          finalize_at = Time.zone.local(entry.date.year, entry.date.month, entry.date.day) +
+                        end_seconds.seconds + 10.minutes
+
+          # Cron may run after a user's shift already ended (e.g. an early-morning shift
+          # finished before 08:00). Skip — nothing to finalize at a past moment.
+          next if finalize_at.past?
+
+          FinalizeUserShiftJob.set(wait_until: finalize_at).perform_later(entry.user_id)
+        end
+      end
+    end
+  end
+end

--- a/app/jobs/finalize_user_shift_job.rb
+++ b/app/jobs/finalize_user_shift_job.rb
@@ -1,0 +1,29 @@
+class FinalizeUserShiftJob < ApplicationJob
+  queue_as :default
+
+  def perform(user_id)
+    user = User.find_by(id: user_id)
+    return unless user
+
+    window = user.elqueue_window
+    return unless window
+
+    # Skip and forget: if the user is actively serving a ticket at T+10,
+    # we don't preempt the service nor reschedule.
+    return if window.serving_client?
+
+    ActiveRecord::Base.transaction do
+      user.resume! if user.paused?
+      user.update!(remember_pause: false) if user.remember_pause?
+      user.free_window
+    end
+
+    ElectronicQueueChannel.broadcast_to(
+      window.electronic_queue,
+      action: 'window_resume',
+      window_number: window.window_number
+    )
+
+    Rails.logger.info("[FinalizeUserShift] finalized user=#{user.id} window=#{window.window_number}")
+  end
+end

--- a/app/models/schedule_entry.rb
+++ b/app/models/schedule_entry.rb
@@ -10,6 +10,7 @@ class ScheduleEntry < ApplicationRecord
   belongs_to :occupation_type
 
   before_validation :clear_work_fields_for_non_working_occupation
+  after_create_commit :schedule_today_finalization, if: :should_schedule_finalization?
 
   validates :date, presence: true
   validates :occupation_type, presence: true
@@ -130,6 +131,26 @@ class ScheduleEntry < ApplicationRecord
     self.shift_id = nil
     self.custom_start_time = nil
     self.custom_end_time = nil
+  end
+
+  def should_schedule_finalization?
+    return false unless occupation_type&.counts_as_working?
+    return false unless effective_end_seconds
+    return false unless schedule_group&.city
+
+    tz = schedule_group.city.time_zone.presence || 'Vladivostok'
+    Time.use_zone(tz) { date == Time.zone.today }
+  end
+
+  def schedule_today_finalization
+    tz = schedule_group.city.time_zone.presence || 'Vladivostok'
+    Time.use_zone(tz) do
+      finalize_at = Time.zone.local(date.year, date.month, date.day) +
+                    effective_end_seconds.seconds + 10.minutes
+      return if finalize_at.past?
+
+      FinalizeUserShiftJob.set(wait_until: finalize_at).perform_later(user_id)
+    end
   end
 
   def custom_shift_times_consistency

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -63,3 +63,9 @@ transcription_silence_check:
   class: 'TranscriptionSilenceCheckJob'
   queue: 'default'
   active_job: true
+
+bootstrap_today_finalizations:
+  cron: '0 8 * * * Asia/Vladivostok'
+  class: 'BootstrapTodayFinalizationsJob'
+  queue: 'default'
+  active_job: true


### PR DESCRIPTION
Releases a user's queue-window seat T+10 after their scheduled shift ends, instead of waiting for User.reset_windows at midnight. The existing reset_windows only calls free_window (without resume! / remember_pause / broadcast), so this is a more complete finalization.

- FinalizeUserShiftJob(user_id): per-user worker. Skips silently if user is serving a ticket at T+10 (no preemption, no reschedule). Otherwise atomically: resume!, clear remember_pause, free_window, broadcast window_resume.
- BootstrapTodayFinalizationsJob: daily cron at 08:00 Asia/Vladivostok. For every City, schedules FinalizeUserShiftJob.set(wait_until: ...) for each today's working ScheduleEntry in the city's local TZ. 08:00 ВЛВ chosen so cities west of VLV (Moscow, etc.) also have "today" by then — 00:05 ВЛВ would still be "yesterday" in МСК.
- ScheduleEntry#after_create_commit: also schedules the job if a today-dated working entry is created after the bootstrap fired (late shift swap). No after_update_commit by design — edits to an existing entry do not reschedule finalization.

The bootstrap+after_create pair may double-schedule for an entry created right before 08:00 — second invocation is a no-op because FinalizeUserShiftJob is idempotent (returns early when window is nil).