### PR TITLE
feat: mark in-progress repairs whose master is off today

### DIFF
--- a/app/assets/stylesheets/repair_status_summary.css.scss
+++ b/app/assets/stylesheets/repair_status_summary.css.scss
@@ -73,6 +73,29 @@
   margin-top: 2px;
 }
 
+.repair-status-summary__attention {
+  position: absolute;
+  top: 4px;
+  right: 6px;
+  background: #d9534f;
+  color: #fff;
+  padding: 1px 7px;
+  border-radius: 9px;
+  font-size: 10px;
+  font-weight: bold;
+  line-height: 14px;
+  white-space: nowrap;
+}
+
+.repair-status-devices__row--attention {
+  background-color: #fcf8e3;
+}
+
+.repair-status-devices__master-unavailable {
+  color: #c9302c;
+  font-weight: bold;
+}
+
 .repair-status-devices__scope {
   color: #777;
   font-weight: normal;

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -78,6 +78,11 @@ class DashboardController < ApplicationController
     @service_jobs = @service_jobs.order(:return_at).to_a
     @include_technician = [RepairStatus::IN_PROGRESS, 'total'].include?(@status_code)
     @current_technicians = @include_technician ? load_current_technicians_for(@service_jobs) : {}
+    @unavailable_master_occupations = if @include_technician
+                                        unavailable_master_occupations(@current_technicians.values.map { |t| t[:user]&.id }.compact.uniq)
+                                      else
+                                        {}
+                                      end
 
     respond_to do |format|
       format.js
@@ -184,8 +189,39 @@ class DashboardController < ApplicationController
     @repair_status_summary = {
       total: counts_by_code.values.sum,
       statuses: statuses.map { |s| { code: s.code, name: s.name, color: s.color, count: counts_by_code[s.code].to_i } },
-      location_name: repair_summary_scope_label(repair_locations)
+      location_name: repair_summary_scope_label(repair_locations),
+      in_progress_attention_count: count_in_progress_with_unavailable_master(repair_locations)
     }
+  end
+
+  # Кол-во устройств в in_progress, чей текущий мастер сегодня не работает по расписанию
+  # (выходной/отпуск/больничный — любой OccupationType с counts_as_working: false).
+  def count_in_progress_with_unavailable_master(repair_locations)
+    in_progress_status = RepairStatus.find_by(code: RepairStatus::IN_PROGRESS)
+    return 0 unless in_progress_status
+
+    in_progress_jobs = ServiceJob.pending
+                         .located_at(repair_locations)
+                         .where(repair_status_id: in_progress_status.id)
+                         .includes(:repair_status)
+                         .to_a
+    return 0 if in_progress_jobs.empty?
+
+    techs = load_current_technicians_for(in_progress_jobs)
+    master_ids = techs.values.map { |t| t[:user]&.id }.compact.uniq
+    unavailable = unavailable_master_occupations(master_ids)
+    techs.count { |_id, tech| unavailable.key?(tech[:user]&.id) }
+  end
+
+  # Возвращает { user_id => OccupationType } для мастеров с нерабочей записью в расписании на дату.
+  # Если у мастера нет записи на дату — он отсутствует в результате (не флагуем нерасписанных юзеров).
+  def unavailable_master_occupations(user_ids, date = Time.zone.today)
+    return {} if user_ids.blank?
+
+    ScheduleEntry.eager_load(:occupation_type)
+      .where(user_id: user_ids, date: date)
+      .where(occupation_types: { counts_as_working: false })
+      .each_with_object({}) { |entry, memo| memo[entry.user_id] = entry.occupation_type }
   end
 
   # nil → не показываем виджет (юзер не имеет отношения к repair-локациям)

--- a/app/views/dashboard/_repair_status_devices_list.html.haml
+++ b/app/views/dashboard/_repair_status_devices_list.html.haml
@@ -16,7 +16,9 @@
       - @service_jobs.each do |sj|
         - status = sj.repair_status
         - tech = (@current_technicians || {})[sj.id]
-        %tr
+        - master_id = tech&.dig(:user)&.id
+        - unavailable_occupation = master_id && (@unavailable_master_occupations || {})[master_id]
+        %tr{ class: ('repair-status-devices__row--attention' if unavailable_occupation && status&.in_progress?) }
           %td
             = link_to sj.ticket_number, service_job_path(sj), target: '_blank'
           %td= sj.device_short_name.presence || '—'
@@ -36,7 +38,12 @@
                     = " (##{displaced.ticket_number})"
           - if @include_technician
             - if status&.in_progress?
-              %td= tech&.dig(:user)&.name || '—'
+              %td
+                = tech&.dig(:user)&.name || '—'
+                - if unavailable_occupation
+                  %br
+                  %small.repair-status-devices__master-unavailable
+                    = t('dashboard.repair_status_summary.attention.master_off', reason: unavailable_occupation.name)
               %td
                 - if tech&.dig(:changed_at)
                   = l(tech[:changed_at], format: :short)

--- a/app/views/dashboard/_repair_status_summary.html.haml
+++ b/app/views/dashboard/_repair_status_summary.html.haml
@@ -12,3 +12,6 @@
           = link_to repair_status_devices_path(status_code: status[:code], location: params[:location]), remote: true, class: "repair-status-summary__tile repair-status-summary__tile--#{status[:code]}", style: ("border-top-color: #{status[:color]};" if status[:color].present?), data: { status_code: status[:code] } do
             .repair-status-summary__count= status[:count]
             .repair-status-summary__label= status[:name]
+            - if status[:code] == RepairStatus::IN_PROGRESS && @repair_status_summary[:in_progress_attention_count].to_i > 0
+              %span.repair-status-summary__attention
+                = t('dashboard.repair_status_summary.attention.badge', count: @repair_status_summary[:in_progress_attention_count])

--- a/config/locales/views/dashboard.ru.yml
+++ b/config/locales/views/dashboard.ru.yml
@@ -48,3 +48,6 @@ ru:
       pause_filter:
         label: "Причина:"
         all: "Все"
+      attention:
+        badge: "%{count} без присмотра"
+        master_off: "Сегодня не работает: %{reason}"


### PR DESCRIPTION
Adds dashboard-summary visibility when an in-progress repair's assigned master has a non-working schedule entry for today. Such devices silently sit unattended otherwise.

UX surface:
- Red "N без присмотра" badge on the "В процессе" tile
- Yellow row + red "Сегодня не работает: <reason>" under the master name in the in_progress and total modals

Decisions:
- "Master off" = ScheduleEntry with OccupationType.counts_as_working=false. Covers vacation/sick/day-off uniformly; is_day_off would miss sick leave (is_day_off=false but counts_as_working=false).
- "No schedule entry" intentionally does NOT flag, to avoid constant noise for masters outside any ScheduleGroup.
- Only in_progress is checked: paused has its own reason field; waiting has no assigned master. Master per job is resolved via the existing load_current_technicians_for helper.