### PR TITLE
feat: show pause reason as second line in repair status widget

### DIFF
--- a/app/assets/stylesheets/repair_status_widget.css.scss
+++ b/app/assets/stylesheets/repair_status_widget.css.scss
@@ -96,6 +96,15 @@
   opacity: 0.85;
 }
 
+.repair-status-badge__reason {
+  display: block;
+  margin-top: 2px;
+  font-size: 10px;
+  font-weight: 400;
+  line-height: 1.2;
+  opacity: 0.9;
+}
+
 .repair-status-widget-modal {
   position: fixed;
   top: 0; left: 0; right: 0; bottom: 0;

--- a/app/views/service_jobs/_repair_status_widget.html.haml
+++ b/app/views/service_jobs/_repair_status_widget.html.haml
@@ -3,17 +3,19 @@
 - current_status = service_job.repair_status
 - current_reason = service_job.repair_pause_reason
 - displaced_by_sj = (current_reason&.urgent_repair? ? service_job.current_displaced_by_service_job : nil)
-- badge_label = (current_reason&.urgent_repair? ? current_reason.name : current_status.name)
 - selectable_statuses = RepairStatus.active.ordered.where.not(code: RepairStatus::COMPLETED)
 
 .repair-status-widget{ data: { 'repair-status-sj-id': service_job.id } }
   - if can?(:update_repair_status, service_job)
     .btn-group
       %a.repair-status-badge{ class: "repair-status-badge--#{current_status.code}", data: { toggle: 'dropdown' }, href: '#', style: ("background: #{current_status.color};" if current_status.color.present?) }
-        = badge_label
-        - if displaced_by_sj
-          %span.repair-status-badge__ref= " ##{displaced_by_sj.ticket_number}"
+        = current_status.name
         %span.caret
+        - if current_status.paused? && current_reason
+          %span.repair-status-badge__reason
+            = current_reason.name
+            - if displaced_by_sj
+              %span.repair-status-badge__ref= " ##{displaced_by_sj.ticket_number}"
       %ul.dropdown-menu.repair-status-widget__menu
         - selectable_statuses.each do |status|
           - if status.paused?
@@ -37,6 +39,9 @@
                 = status.name
   - else
     %span.repair-status-badge{ class: "repair-status-badge--#{current_status.code}", style: ("background: #{current_status.color};" if current_status.color.present?) }
-      = badge_label
-      - if displaced_by_sj
-        %span.repair-status-badge__ref= " ##{displaced_by_sj.ticket_number}"
+      = current_status.name
+      - if current_status.paused? && current_reason
+        %span.repair-status-badge__reason
+          = current_reason.name
+          - if displaced_by_sj
+            %span.repair-status-badge__ref= " ##{displaced_by_sj.ticket_number}"


### PR DESCRIPTION
Previously the badge showed only "Пауза" for non-urgent pauses, hiding which reason it was (Ждём запчасть / Ждём согласования / Нужен другой мастер). Only urgent_repair had its reason visible — by replacing the "Пауза" label entirely with "Срочный ремонт #<ticket>", which was both inconsistent with other pauses and lost the "Пауза" word.

Unified: the badge always shows status.name on line 1; for paused status, reason.name appears on line 2 (smaller, semi-transparent). The displaced ticket number stays appended inline in the reason text for urgent_repair.

No DB changes — data is already available via the existing service_jobs.repair_pause_reason FK; this is rendering-only. Affects all four widget surfaces (show header, under tasks table, edit modal header, dashboard row) through the shared partial.