### PR TITLE
fix: exclude fired employees from statistics leaderboard

### DIFF
--- a/app/queries/employee_statistics_query.rb
+++ b/app/queries/employee_statistics_query.rb
@@ -26,7 +26,8 @@ class EmployeeStatisticsQuery
   attr_reader :metric, :month, :city_id
 
   def eligible_users
-    User.joins(:department)
+    User.active
+        .joins(:department)
         .where(departments: { city_id: city_id })
         .where('users.activities_mask & ? > 0', activity_bit)
         .order(:name)


### PR DESCRIPTION
EmployeeStatisticsQuery only filtered by city and activities_mask, so terminated employees with the right mask still appeared in the leaderboard. On dev this was masked by tiny data, but in production years of fired staff would clutter the table.

Chain User.active (is_fired IN (false, NULL)) into eligible_users so only currently-employed people show up. The NULL branch covers legacy rows from before the column got a default.