### PR TITLE
fix: use short_name for employees on statistics leaderboard

### DIFF
--- a/app/views/personnel/statistics/show.html.haml
+++ b/app/views/personnel/statistics/show.html.haml
@@ -43,7 +43,7 @@
               %td
                 - if user.photo?
                   = image_tag user.photo.thumb.url, class: 'employee-statistics__avatar'
-              %td{ class: ('employee-statistics__name--achieved' if achieved.call(count)) }= user.name
+              %td{ class: ('employee-statistics__name--achieved' if achieved.call(count)) }= user.short_name
               %td{style: 'text-align: right;'}= count
         %tfoot
           %tr.employee-statistics__plan-row


### PR DESCRIPTION
User#name is the AR column for the first name only ("Иван"), which looks incomplete on a city-wide leaderboard where multiple people can share a first name. Switch to User#short_name (name + surname with a username fallback) for a less ambiguous display.