### PR TITLE
fix: refine statistics table layout, highlight and month case

### DIFF
--- a/app/assets/stylesheets/employee_statistics.css.scss
+++ b/app/assets/stylesheets/employee_statistics.css.scss
@@ -48,7 +48,8 @@
   }
 
   &__table {
-    margin-bottom: 0;
+    max-width: 70%;
+    margin: 0 auto;
     background-color: transparent;
   }
 
@@ -58,9 +59,9 @@
     border-radius: 50%;
   }
 
-  &__name--achieved {
-    background-color: #5cb85c !important;
-    color: #fff;
+  &__row--achieved > td {
+    background-color: #a8d8a8 !important;
+    color: #000;
     font-weight: bold;
   }
 

--- a/app/helpers/personnel/statistics_helper.rb
+++ b/app/helpers/personnel/statistics_helper.rb
@@ -6,8 +6,12 @@ module Personnel
       first = Date.current.beginning_of_month
       (0..MONTHS_BACK).map do |offset|
         date = (first << offset)
-        [l(date, format: '%B %Y'), date.to_s]
+        [nominative_month_year(date), date.to_s]
       end
+    end
+
+    def nominative_month_year(date)
+      "#{I18n.t('date.month_names_single')[date.month]} #{date.year}"
     end
   end
 end

--- a/app/views/personnel/statistics/show.html.haml
+++ b/app/views/personnel/statistics/show.html.haml
@@ -25,7 +25,7 @@
                   personnel_statistics_path(metric: m, month: @month.to_s, city_id: @city.id)
 
   .employee-statistics__panel{ class: "employee-statistics__panel--#{@metric}" }
-    %h3= "#{t("personnel.statistics.metrics.#{@metric}")} — #{l(@month, format: '%B %Y')}, #{@city.name}"
+    %h3= "#{t("personnel.statistics.metrics.#{@metric}")} — #{nominative_month_year(@month)}, #{@city.name}"
 
     - if @rows.empty?
       %p.muted= t('.empty')
@@ -39,11 +39,11 @@
         %tbody
           - achieved = ->(count) { @plan.target.to_i.positive? && count >= @plan.target.to_i }
           - @rows.each do |user, count|
-            %tr
+            %tr{ class: ('employee-statistics__row--achieved' if achieved.call(count)) }
               %td
                 - if user.photo?
                   = image_tag user.photo.thumb.url, class: 'employee-statistics__avatar'
-              %td{ class: ('employee-statistics__name--achieved' if achieved.call(count)) }= user.short_name
+              %td= user.short_name
               %td{style: 'text-align: right;'}= count
         %tfoot
           %tr.employee-statistics__plan-row


### PR DESCRIPTION
Narrow the leaderboard table to 70% and center it; the full-width table felt too sparse inside the colored panel.

Move the "achieved plan" highlight from the name cell to the whole row (bold black text on green background) so the row reads as a single stripe. Soften the green from #5cb85c to #a8d8a8 to fit the surrounding pastel tab panels.

Use the nominative-case month name ("Май 2026") instead of the default genitive ("мая 2026") in the month dropdown and the panel heading. rails-i18n's %B returns genitive (suited for inline dates like "27 мая 2026"); we pull from the project-local date.month_names_single array via a new nominative_month_year helper, keeping selector and heading in sync.