### PR TITLE
style: narrow employee statistics table to 50% width

### DIFF
--- a/app/assets/stylesheets/employee_statistics.css.scss
+++ b/app/assets/stylesheets/employee_statistics.css.scss
@@ -48,7 +48,7 @@
   }
 
   &__table {
-    max-width: 70%;
+    max-width: 50%;
     margin: 0 auto;
     background-color: transparent;
   }


### PR DESCRIPTION
Tighten the leaderboard table from 70% to 50% of the panel; the previous width still felt too loose with only three columns (avatar / name / number) inside the wide colored panel.