### PR TITLE
feat: color topbar notification icon by notification kind

### DIFF
--- a/app/assets/stylesheets/_topbar.css.scss
+++ b/app/assets/stylesheets/_topbar.css.scss
@@ -166,12 +166,12 @@ svg#letter-icon {
   stroke-width: 16px;
 }
 
-// только склейка стекла — синий
-.active-notifications.active-notifications--gluing svg#letter-icon {
+// только наклейка стекла — синий
+.active-notifications.active-notifications--glass svg#letter-icon {
   stroke: #2b6cb0;
 }
 
-// склейка + другие уведомления — пульсация красный↔синий
+// наклейка стекла + другие уведомления — пульсация красный↔синий
 .active-notifications.active-notifications--mixed svg#letter-icon {
   animation: letter-mixed-flash 1s infinite alternate ease-in-out;
 }

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -31,10 +31,10 @@ class NotificationsController < ApplicationController
 
     scope = current_user.notifications.not_closed
     @notifications = scope.page(params[:page])
-    # Флаги для цвета иконки в topbar: синий — только склейка,
+    # Флаги для цвета иконки в topbar: синий — только наклейка стекла,
     # красный — только прочие, красно-синий — и то, и другое.
-    @has_gluing = scope.gluing.exists?
-    @has_other  = scope.non_gluing.exists?
+    @has_glass = scope.glass_sticking.exists?
+    @has_other = scope.non_glass_sticking.exists?
 
     respond_to(&:js)
   end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -18,18 +18,19 @@ class Notification < ApplicationRecord
     nil                        => 'Без типа'
   }.freeze
 
-  # kind уведомления о склейке стекла (см. RepairGluingReminderJob).
+  # kind уведомления от стекольщика/гравировщика о наклейке стекла
+  # («устройство готово» / «проблема с устройством»), см. GlassStickingController.
   # Цвет иконки уведомлений в topbar зависит от наличия именно этого kind.
-  GLUING_KIND = 'repair_gluing'.freeze
+  GLASS_STICKING_KIND = 'glass_sticking'.freeze
 
   belongs_to :user
   belongs_to :referenceable, polymorphic: true, optional: true
 
-  scope :not_closed, -> { where(closed_at: nil) }
-  scope :gluing,     -> { where(kind: GLUING_KIND) }
-  # IS DISTINCT FROM, а не <>: в Postgres `kind <> 'repair_gluing'` отбросил бы
+  scope :not_closed,         -> { where(closed_at: nil) }
+  scope :glass_sticking,     -> { where(kind: GLASS_STICKING_KIND) }
+  # IS DISTINCT FROM, а не <>: в Postgres `kind <> 'glass_sticking'` отбросил бы
   # все строки с kind IS NULL (а это большинство «обычных» уведомлений).
-  scope :non_gluing, -> { where('kind IS DISTINCT FROM ?', GLUING_KIND) }
+  scope :non_glass_sticking, -> { where('kind IS DISTINCT FROM ?', GLASS_STICKING_KIND) }
 
   validates :user_id, :message, presence: true
 

--- a/app/views/notifications/user_notifications.js.erb
+++ b/app/views/notifications/user_notifications.js.erb
@@ -1,14 +1,14 @@
 <%# Единственный авторитетный источник состояния иконки уведомлений. %>
 <%# Сбрасываем все классы и заново выставляем нужный — так путь работает %>
 <%# одинаково при загрузке страницы и при realtime-перерисовке. %>
-$("#user_notifications").removeClass("active-notifications active-notifications--gluing active-notifications--mixed");
+$("#user_notifications").removeClass("active-notifications active-notifications--glass active-notifications--mixed");
 
 <% if @notifications.present? %>
   $("#user_notifications").addClass("active-notifications");
-  <% if @has_gluing && @has_other %>
+  <% if @has_glass && @has_other %>
     $("#user_notifications").addClass("active-notifications--mixed");
-  <% elsif @has_gluing %>
-    $("#user_notifications").addClass("active-notifications--gluing");
+  <% elsif @has_glass %>
+    $("#user_notifications").addClass("active-notifications--glass");
   <% end %>
   $("#user_notifications").attr("data-content", "<%= j render(collection: @notifications, partial: "short_notification", as: :notification) %>");
 <% else %>


### PR DESCRIPTION
The envelope icon used a single red "lit" state. Now its color reflects which kinds of open notifications the user has:
  - glass-sticking only        -> solid blue
  - glass-sticking + others    -> pulsing red<->blue
  - others only / none         -> red (unchanged)

"Glass-sticking" is the engraver/glass-master -> bar message ("device ready" / "device problem"), kind = 'glass_sticking' (GlassStickingController). Color is computed server-side in the user_notifications endpoint (single source of truth); the ActionCable channel refreshes that state via getScript instead of toggling the class by hand, so realtime and page-load paths agree.