### PR TITLE
fix: avoid 500 when filled sale fails validation in create_sale

### DIFF
--- a/app/controllers/service_jobs_controller.rb
+++ b/app/controllers/service_jobs_controller.rb
@@ -375,10 +375,11 @@ class ServiceJobsController < ApplicationController
           else
             format.html { redirect_to service_job.sale }
           end
-        elsif (sale = service_job.create_filled_sale).present?
+        elsif (sale = service_job.create_filled_sale).persisted?
           format.html { redirect_to edit_sale_path(sale) }
         else
-          format.html { head :no_content }
+          error_msg = sale.errors.full_messages.to_sentence.presence || 'Не удалось создать продажу'
+          format.html { redirect_to service_job, alert: error_msg }
         end
       else
         format.html { render plain: 'Вы находитесь на разных подразделениях с устройством. Смените подразделение' }


### PR DESCRIPTION
create_filled_sale uses the AR `create_sale` association builder, which returns an unsaved Sale (id: nil) on validation failure instead of raising. The controller guarded on `.present?`, which is true for any non-nil object, so it fell through to `edit_sale_path(sale)` with a nil id and raised UrlGenerationError.

Guard on `.persisted?` instead, and on failure redirect back to the service job with the validation errors in a flash alert so the employee sees why the sale was not created.