### PR TITLE
feat: add action-needed count badge to Testing nav link

### DIFF
--- a/app/assets/stylesheets/testings.css.scss
+++ b/app/assets/stylesheets/testings.css.scss
@@ -3,6 +3,30 @@
 // generic-селекторы (.table, .icon-ok) НЕ трогаем — см. CONTEXT.md.
 // Палитра согласована с repair_status_summary.css.scss.
 
+// ── Бейдж-счётчик на ссылке «Тестирование» в навбаре дашборда ───────────────
+// Красный кружок с числом устройств, ждущих начала теста (not_started) —
+// как счётчик непрочитанных. Палитра/форма зеркалят .repair-status-summary__
+// attention. Сидит «надстрочно» в правом верхнем углу, слегка наезжая на
+// последнюю букву слова: остаётся в инлайн-потоке (последний элемент внутри
+// ссылки), а relative + отрицательные top/left поднимают и сдвигают его на
+// текст — так он привязан к букве, а не к правому краю ссылки с её padding'ом.
+.testings-nav-badge {
+  position: relative;
+  top: -0.9em;
+  left: -0.4em;
+  display: inline-block;
+  min-width: 8px;
+  padding: 0 6px;
+  background: #d9534f;
+  color: #fff;
+  border-radius: 10px;
+  font-size: 11px;
+  font-weight: bold;
+  line-height: 16px;
+  text-align: center;
+  vertical-align: baseline;
+}
+
 // ── Витрина «ТЕСТИРОВАНИЕ» (входящие) — /testings ───────────────────────────
 #testings_table {
   // Акцентная рамка + шапка: сущность визуально выделяется (ТЗ §2).

--- a/app/controllers/testings_controller.rb
+++ b/app/controllers/testings_controller.rb
@@ -87,9 +87,9 @@ class TestingsController < ApplicationController
 
   # Сессии, доступные текущему сотруднику: его локация (у админов без
   # локации — все). Используется и для списка, и для проверки прав на старт.
+  # Тот же scope питает счётчик-бейдж в навбаре (см. dashboard/index) — выборка
+  # подсветки и цифры бейджа намеренно одна.
   def accessible_sessions
-    scope = TestingSession.all
-    scope = scope.where(target_location_id: current_user.location_id) if current_user.location_id.present?
-    scope
+    TestingSession.for_tester(current_user)
   end
 end

--- a/app/models/testing_session.rb
+++ b/app/models/testing_session.rb
@@ -37,6 +37,13 @@ class TestingSession < ApplicationRecord
   scope :in_department, lambda { |department|
     joins(:service_job).where(service_jobs: { department_id: department })
   }
+  # Сессии, доступные сотруднику как тестировщику: ограничены его локацией
+  # (target_location). У админов без локации — все. Единый источник и для
+  # витрины /testings (что видно/подсвечено), и для счётчика-бейджа в навбаре,
+  # чтобы цифра бейджа всегда совпадала с числом строк на странице.
+  scope :for_tester, lambda { |user|
+    user&.location_id.present? ? where(target_location_id: user.location_id) : all
+  }
 
   # Длительность теста в секундах (nil, пока тест не завершён).
   def duration

--- a/app/views/dashboard/index.html.haml
+++ b/app/views/dashboard/index.html.haml
@@ -22,7 +22,12 @@
           %li.actual_requests_nav= link_to t('dashboard.actual_requests'), actual_supply_requests_path, remote: true
       %li.ready_service_jobs_nav= link_to t('dashboard.ready_service_jobs'), ready_service_jobs_path, remote: true
       - if current_user.any_admin? || current_user.location&.for_testing?
-        %li.testings_nav= link_to t('dashboard.testings'), testings_path
+        - testings_action_needed = TestingSession.for_tester(current_user).not_started.count
+        %li.testings_nav
+          = link_to testings_path do
+            = t('dashboard.testings')
+            - if testings_action_needed > 0
+              %span.testings-nav-badge{ title: t('dashboard.testings_action_needed_hint', count: testings_action_needed, default: "Не начатых тестов: #{testings_action_needed}") }= testings_action_needed
       - if current_user.any_admin? || current_user.location&.is_any_repair?
         %li.returned_testings_nav= link_to t('dashboard.returned_testings'), returned_testings_path
       %li.all_service_jobs_nav= link_to t('dashboard.all_service_jobs'), service_jobs_path

--- a/config/locales/views/dashboard.ru.yml
+++ b/config/locales/views/dashboard.ru.yml
@@ -11,6 +11,7 @@ ru:
     all_service_jobs: "Все работы"
     ready_service_jobs: "Готовые работы"
     testings: "Тестирование"
+    testings_action_needed_hint: "Устройств ждут начала тестирования: %{count}"
     returned_testings: "Вернулось с тестирования"
     misc: 'Прочее'
     moved_title: 'Перемещен'


### PR DESCRIPTION
Show a red count bubble on the "Тестирование" navbar link with the number of not-started sessions awaiting the user — same idea as an unread-messages counter. The number always equals the highlighted rows on /testings.

Extract the tester-visibility logic into a TestingSession.for_tester scope and feed both the page (via accessible_sessions) and the badge from it, so the count can never drift from what the page shows. Reuse the app's existing attention-bubble look as a scoped BEM class.