### PR TITLE
feat: add action-needed count badge to Returned-testing nav link

### DIFF
--- a/app/models/testing_session.rb
+++ b/app/models/testing_session.rb
@@ -44,6 +44,19 @@ class TestingSession < ApplicationRecord
   scope :for_tester, lambda { |user|
     user&.location_id.present? ? where(target_location_id: user.location_id) : all
   }
+  # «Требуют действия» на витрине /returned: провалены с возвратом технарю И
+  # ремонт всё ещё на паузе (технарь не нажал «Продолжить ремонт»). Предикат
+  # дословно повторяет условие подсветки строки в _returned_session
+  # (failed? && service_job.repair_status&.paused?) — чтобы счётчик-бейдж в
+  # навбаре всегда совпадал с числом подсвеченных строк. Один JOIN на
+  # service_job→repair_status (department-фильтр здесь же, без in_department,
+  # иначе Rails 5.1 продублировал бы join к service_jobs).
+  scope :awaiting_resume_in, lambda { |department|
+    where(status: 'failed', failure_action: FAILURE_ACTIONS[:return_to_tech])
+      .joins(service_job: :repair_status)
+      .where(repair_statuses: { code: RepairStatus::PAUSED })
+      .where(service_jobs: { department_id: department })
+  }
 
   # Длительность теста в секундах (nil, пока тест не завершён).
   def duration

--- a/app/views/dashboard/index.html.haml
+++ b/app/views/dashboard/index.html.haml
@@ -29,7 +29,12 @@
             - if testings_action_needed > 0
               %span.testings-nav-badge{ title: t('dashboard.testings_action_needed_hint', count: testings_action_needed, default: "Не начатых тестов: #{testings_action_needed}") }= testings_action_needed
       - if current_user.any_admin? || current_user.location&.is_any_repair?
-        %li.returned_testings_nav= link_to t('dashboard.returned_testings'), returned_testings_path
+        - returned_action_needed = TestingSession.awaiting_resume_in(current_department).count
+        %li.returned_testings_nav
+          = link_to returned_testings_path do
+            = t('dashboard.returned_testings')
+            - if returned_action_needed > 0
+              %span.testings-nav-badge{ title: t('dashboard.returned_action_needed_hint', count: returned_action_needed, default: "Ждут продолжения ремонта: #{returned_action_needed}") }= returned_action_needed
       %li.all_service_jobs_nav= link_to t('dashboard.all_service_jobs'), service_jobs_path
 
 #dashboard_table_filter= render @table_name+'_filter'

--- a/config/locales/views/dashboard.ru.yml
+++ b/config/locales/views/dashboard.ru.yml
@@ -13,6 +13,7 @@ ru:
     testings: "Тестирование"
     testings_action_needed_hint: "Устройств ждут начала тестирования: %{count}"
     returned_testings: "Вернулось с тестирования"
+    returned_action_needed_hint: "Ждут продолжения ремонта после неудачного теста: %{count}"
     misc: 'Прочее'
     moved_title: 'Перемещен'
     new_service_job: 'Приёмка девайса'


### PR DESCRIPTION
Mirror the /testings badge on the "Вернулось с тестирования" link: a red bubble with the number of devices that came back from a failed test and still wait for the technician to resume the repair.

Add TestingSession.awaiting_resume_in(department) — failed + return_to_tech + repair still paused, in the user's department. The predicate matches the row-highlight condition on /returned exactly, so the badge count always equals the highlighted rows. It uses a single service_job -> repair_status join (filtering on the globally unique repair_statuses.code) rather than chaining in_department, which would duplicate the service_jobs join on Rails 5.1.

Reuse the existing .testings-nav-badge style (no new CSS); add the returned_action_needed_hint title locale.