### PR TITLE
fix: guard nil spare_parts_store in RepairTask after_initialize

### DIFF
--- a/app/models/repair_task.rb
+++ b/app/models/repair_task.rb
@@ -25,7 +25,7 @@ class RepairTask < ApplicationRecord
 
   after_initialize do
     self.price ||= repair_service&.price(department)&.value
-    self.store_id = Department.current.spare_parts_store.id
+    self.store_id ||= Department.current&.spare_parts_store&.id
     # self.store_id = User.current.try(:spare_parts_store).try(:id)
     if repair_service.present? and repair_parts.empty?
       repair_service.spare_parts.each do |spare_part|


### PR DESCRIPTION
RepairTask#after_initialize fired on every instantiation (including DB loads) and called Department.current.spare_parts_store.id unconditionally. For departments without a spare-parts store this raised NoMethodError (nil.id), 500-ing any page that loaded a RepairTask under such a department — e.g. service_jobs#show via DeviceTask#available_check_lists.

Use safe navigation and ||= so store_id falls back to nil instead of crashing, and a persisted store_id is no longer overwritten on load.