### PR TITLE
feat: add user search filter to kanban card form

### DIFF
--- a/app/views/kanban/cards/_form.html.erb
+++ b/app/views/kanban/cards/_form.html.erb
@@ -15,7 +15,10 @@
     <div class='span8'>
       <div class="control-group kanban-managers">
         <%= form.label :managers, class: 'control-label' %>
-        <div class="controls">
+        <div class="controls kanban-user-choice">
+          <%= text_field_tag "manager_user", nil, placeholder: t(".filter_user"), class: "filter-kanban-users" %>
+          <%= link_to t(".check_all"), "", class: "btn btn-secondary check-all-users" %>
+          <%= link_to t(".uncheck_all"), "", class: "btn btn-secondary uncheck-all-users" %>
           <%= form.collection_check_boxes :manager_ids, User.active, :id, :presentation do |b| %>
             <%= b.check_box %>
             <%= b.label class: 'label-card-managers' %>

--- a/config/locales/kanban.ru.yml
+++ b/config/locales/kanban.ru.yml
@@ -35,6 +35,10 @@ ru:
       updated: 'Колонка изменена'
       destroyed: 'Колонка удалена'
     cards:
+      form:
+        check_all: Отметить всех
+        uncheck_all: Снять отметки со всех
+        filter_user: Поиск...
       edit:
         title: 'Редактирование Карточки'
       new:


### PR DESCRIPTION
Add the same jQuery live-filter and check/uncheck-all controls to the card managers picker that the board form already has. Reuses the existing .filter-kanban-users / .kanban-user-choice classes, so no JS or CSS changes are needed — only the card form markup and new kanban.cards.form locale keys.