### PR TITLE
feat: allow superadmins to edit client requests

### DIFF
--- a/app/controllers/client_requests_controller.rb
+++ b/app/controllers/client_requests_controller.rb
@@ -29,6 +29,33 @@ class ClientRequestsController < ApplicationController
     end
   end
 
+  # Полное редактирование запроса — ТОЛЬКО superadmin (find_record авторизует
+  # через edit?/update?). Позволяет исправить устройство (ошибочный серийник),
+  # комментарий и вручную проставить дату покупки.
+  def edit
+    @client_request = find_record ClientRequest
+  end
+
+  def update
+    @client_request = find_record ClientRequest
+    attrs = client_request_edit_params
+    attrs[:sold_at] = parse_sold_at(attrs[:sold_at])
+    @client_request.assign_attributes(attrs)
+
+    item_changed = @client_request.item_id_changed?
+    # Ручной ввод даты покупки = подтверждаем покупку вручную (раз 1С не смогла).
+    @client_request.purchase_check_status = :confirmed if @client_request.sold_at.present?
+
+    if @client_request.save
+      # Сменили устройство, а дату руками не задали → перепроверить покупку в 1С
+      # с новым серийником (см. after_commit на create — здесь дёргаем явно).
+      CheckClientRequestPurchaseJob.perform_later(@client_request.id) if item_changed && @client_request.sold_at.blank?
+      redirect_to client_requests_path, notice: t('.updated')
+    else
+      render :edit
+    end
+  end
+
   # Смена workflow-статуса (в работу / выполнен / не выполнен) ИЛИ ручная
   # пометка покупки неподтверждённой — обе через одну кнопку-ссылку remote:true.
   # find_record авторизует через update_status? (action_name → предикат policy).
@@ -56,6 +83,22 @@ class ClientRequestsController < ApplicationController
 
   def client_request_params
     params.require(:client_request).permit(:client_id, :item_id, :reason)
+  end
+
+  # При редактировании клиента не меняем (запрос привязан к тому же клиенту);
+  # зато разрешаем устройство, комментарий и ручную дату покупки.
+  def client_request_edit_params
+    params.require(:client_request).permit(:item_id, :reason, :sold_at)
+  end
+
+  # Datepicker шлёт дату как 'дд.мм.гггг'. Date.parse на таком формате
+  # неоднозначен (06.07 → день или месяц?), поэтому разбираем строго strptime.
+  def parse_sold_at(value)
+    return if value.blank?
+
+    Date.strptime(value, '%d.%m.%Y')
+  rescue ArgumentError
+    nil
   end
 
   # Разрешаем менять только эти два enum-поля. Кнопки шлют ровно одно из них.

--- a/app/models/history_observer.rb
+++ b/app/models/history_observer.rb
@@ -26,7 +26,7 @@ class HistoryObserver < ActiveRecord::Observer
     elsif model.is_a? ClientCharacteristic
       tracked_attributes = %w[comment client_category_id]
     elsif model.is_a? ClientRequest
-      tracked_attributes = %w[status purchase_check_status reason]
+      tracked_attributes = %w[status purchase_check_status reason sold_at]
     end
 
     unless (changed_attributes_keys = tracked_attributes & model.changed_attributes.keys).empty?

--- a/app/policies/client_request_policy.rb
+++ b/app/policies/client_request_policy.rb
@@ -1,10 +1,15 @@
 class ClientRequestPolicy < ApplicationPolicy
-  # Запросы клиентов полностью открыты: любой залогиненный сотрудник может
-  # просматривать список/карточку, создавать, обрабатывать (смена статуса /
-  # редактирование) и удалять запросы. Галочка work_with_receipt_search_requests
+  # Запросы клиентов в основном открыты: любой залогиненный сотрудник может
+  # просматривать список/карточку, создавать, обрабатывать (смена статуса через
+  # update_status?) и удалять запросы. Галочка work_with_receipt_search_requests
   # и роль superadmin больше нигде не требуются — сознательное решение в ветке
   # 159-client-requests-receipt-search (адресаты уведомлений при этом остаются
   # прежними: superadmin ∪ галочка — см. ClientRequest.notification_recipients).
+  #
+  # ИСКЛЮЧЕНИЕ (ветка 161-client-requests-edit): полное редактирование
+  # (устройство / дата покупки / комментарий через edit?/update?) — ТОЛЬКО
+  # superadmin. Это правка «фактуры» запроса (исправление ошибочного серийника,
+  # ручная простановка даты покупки), поэтому права у́же, чем у смены статуса.
   def index?
     true
   end
@@ -27,11 +32,11 @@ class ClientRequestPolicy < ApplicationPolicy
   end
 
   def update?
-    true
+    superadmin?
   end
 
   def edit?
-    true
+    superadmin?
   end
 
   # Кастомный member-экшен — Pundit требует одноимённый предикат.

--- a/app/views/client_requests/_client_request.html.haml
+++ b/app/views/client_requests/_client_request.html.haml
@@ -34,4 +34,6 @@
           = link_to t('.failed_btn'), update_status_client_request_path(cr, client_request: { status: :failed }), method: :patch, remote: true, class: 'btn btn-danger btn-small'
         - unless cr.unconfirmed?
           = link_to t('.mark_unconfirmed_btn'), update_status_client_request_path(cr, client_request: { purchase_check_status: :unconfirmed }), method: :patch, remote: true, class: 'btn btn-small'
+    - if policy(cr).edit?
+      = link_to glyph(:pencil), edit_client_request_path(cr), class: 'btn btn-small', title: t('.edit_btn')
     = history_link_to history_client_request_path(cr)

--- a/app/views/client_requests/_form.html.haml
+++ b/app/views/client_requests/_form.html.haml
@@ -4,9 +4,21 @@
       - if f.object.errors.any?
         .alert.alert-error= f.object.errors.full_messages.join('. ')
 
-      = f.input :client, as: :client, wrapper_html: { id: 'client_fields' }, no_devices: true
+      -# При создании клиента ищем/заводим; при редактировании запрос привязан
+      -# к тому же клиенту — показываем его только для чтения.
+      - if f.object.persisted?
+        .control-group
+          %label.control-label= ClientRequest.human_attribute_name(:client)
+          .controls
+            %span.uneditable-input= f.object.client.short_name
+      - else
+        = f.input :client, as: :client, wrapper_html: { id: 'client_fields' }, no_devices: true
       = f.input :item, as: :device, required: true
       = f.input :reason, as: :text, input_html: { rows: 5 }
+      -# Ручная простановка даты покупки — только в редактировании (см. контроллер:
+      -# заполненная дата → purchase_check_status = confirmed).
+      - if f.object.persisted?
+        = f.input :sold_at, as: :string, input_html: { value: (f.object.sold_at && l(f.object.sold_at)), class: 'datepicker input-medium', data: { 'date-language' => 'ru', 'date-format' => 'dd.mm.yyyy', 'date-weekstart' => 1, 'date-viewmode' => 'days' } }
       .form-actions
         = submit_button f
 

--- a/app/views/client_requests/edit.html.haml
+++ b/app/views/client_requests/edit.html.haml
@@ -1,0 +1,4 @@
+.page-header
+  %h2= t('.title')
+
+= render 'form'

--- a/config/locales/views/client_requests.ru.yml
+++ b/config/locales/views/client_requests.ru.yml
@@ -10,8 +10,12 @@ ru:
       title: Запрос на поиск чека
     new:
       title: Новый запрос на поиск чека
+    edit:
+      title: Редактирование запроса
     create:
       created: Запрос создан
+    update:
+      updated: Запрос обновлён
     update_status:
       updated: Статус обновлён
     client_section:
@@ -22,6 +26,7 @@ ru:
       done_btn: Выполнен
       failed_btn: Не выполнен
       mark_unconfirmed_btn: Покупка не подтверждена
+      edit_btn: Редактировать
     kinds:
       receipt_search: Поиск оригинального чека
       device_unblock: Разблокировка устройства


### PR DESCRIPTION
Add edit/update actions to ClientRequestsController, restricted to superadmins via ClientRequestPolicy (other actions stay open). Editable fields: device (item_id), comment (reason) and a manually entered purchase date (sold_at).

A manually entered sold_at marks the purchase as confirmed (so the request drops out of the daily follow-up reminder). Changing the device with no manual date re-enqueues CheckClientRequestPurchaseJob to re-check the purchase in 1C against the corrected serial number.

Track sold_at in HistoryObserver; show client read-only and a datepicker sold_at field in edit mode; add a pencil edit link gated by the policy.