### PR TITLE
feat: open Quack Control to all repair-location staff

### DIFF
--- a/app/helpers/top_bar_helper.rb
+++ b/app/helpers/top_bar_helper.rb
@@ -60,12 +60,11 @@ module TopBarHelper
             data: {html: true, placement: 'bottom', title: "Кто? И сколько работает в компании?"}
   end
 
-  # Иконка «Ой» → страница «Кря-контроль». Видна тем же, кого пускает
-  # QuackControlPolicy#show?: технарю на ремонтной локации или супер-админу.
+  # Иконка «Ой» → страница «Кря-контроль». Видимость делегирована политике,
+  # чтобы не расходиться с доступом к самой странице (QuackControlPolicy#show?:
+  # сотрудник на ремонтной локации или супер-админ).
   def header_link_to_quack_control
-    visible = (current_user.technician? && current_user.location&.is_any_repair?) ||
-              current_user.superadmin?
-    return unless visible
+    return unless policy(:quack_control).show?
 
     link_to t('quack_control.icon_label'), quack_control_path,
             class: 'quack-control__nav-icon', title: t('quack_control.show.title')

--- a/app/policies/quack_control_policy.rb
+++ b/app/policies/quack_control_policy.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 # Headless policy для страницы «Кря-контроль».
-# Доступ: технари (роль technician), сидящие на любой ремонтной локации,
-# плюс супер-админы. Намеренно НЕ через DB-Ability.
+# Доступ: любой сотрудник, сидящий на любой ремонтной локации (вне зависимости
+# от роли), плюс супер-админы. Намеренно НЕ через DB-Ability.
 class QuackControlPolicy < ApplicationPolicy
   def show?
-    (user.technician? && user.location&.is_any_repair?) || superadmin?
+    user.location&.is_any_repair? || superadmin?
   end
 end

--- a/app/queries/quack_control_query.rb
+++ b/app/queries/quack_control_query.rb
@@ -7,7 +7,7 @@
 # (`notified_at` присутствует), а работа так и не была взята (`processed_action`
 # не 'started', включая NULL = проигнорировал). Период фильтруется по `viewed_at`.
 #
-# Строки = только активные технари (роль technician): на текущей ремонтной локации
+# Строки = активные сотрудники (любая роль) на текущей ремонтной локации
 # (code repair*) + те, у кого за период был хотя бы один засчитанный маркер
 # (на случай ухода с ремонта). Сортировка: count desc, затем имя.
 class QuackControlQuery
@@ -39,14 +39,14 @@ class QuackControlQuery
       .count
   end
 
-  # Только технари (роль technician): и текущие на ремонте, и «нагрешившие» за период.
+  # Активные сотрудники (любая роль): и текущие на ремонте, и «нагрешившие» за период.
   def relevant_users(user_ids_with_markers)
-    User.active.technician.where(id: repair_technician_ids | user_ids_with_markers)
+    User.active.where(id: repair_location_user_ids | user_ids_with_markers)
   end
 
-  # Активные технари, чья текущая локация — любая ремонтная (code LIKE 'repair%')
-  def repair_technician_ids
-    User.active.technician
+  # Активные сотрудники, чья текущая локация — любая ремонтная (code LIKE 'repair%')
+  def repair_location_user_ids
+    User.active
         .joins(:location)
         .where("locations.code LIKE ?", 'repair%')
         .pluck(:id)


### PR DESCRIPTION
Access, anti-rating roster and the topbar icon were limited to technicians on a repair location. Widen all three to any active user whose current location is a repair one (code repair*); superadmins unchanged.

- QuackControlPolicy#show?: drop the technician? role check, gate on location.is_any_repair? || superadmin? only
- QuackControlQuery: drop .technician from the roster; rename repair_technician_ids -> repair_location_user_ids. Marker-based safety net (users who left repair mid-month) is preserved
- top_bar_helper: the icon condition duplicated the old rule; delegate to policy(:quack_control).show? so visibility can't drift from access