### PR TITLE
fix: make strict-repair modal close (×) behave like decline

### DIFF
--- a/app/assets/stylesheets/repair_status_widget.css.scss
+++ b/app/assets/stylesheets/repair_status_widget.css.scss
@@ -145,8 +145,9 @@
   line-height: 1;
   cursor: pointer;
   color: #999;
+  text-decoration: none;
 
-  &:hover { color: #333; }
+  &:hover { color: #333; text-decoration: none; }
 }
 
 .repair-status-widget-modal__body {

--- a/app/views/service_jobs/_take_to_work_modal.html.haml
+++ b/app/views/service_jobs/_take_to_work_modal.html.haml
@@ -5,7 +5,12 @@
   .repair-status-widget-modal__dialog
     .repair-status-widget-modal__header
       %h4= t('service_jobs.strict_repair.take_to_work.title')
-      %button.repair-status-widget-modal__close{ type: 'button', 'aria-label': 'Close', data: { strict_repair_modal_close_for: service_job.id } } ×
+      -# Крестик ведёт себя как «Нет»: тот же POST dismiss_reveal (маркер → dismissed,
+      -# вуаль возвращается). Делегированный хендлер ловит dismiss-for → закрывает клиентски.
+      = link_to '×', dismiss_reveal_service_job_path(service_job),
+                method: :post, remote: true,
+                class: 'repair-status-widget-modal__close', 'aria-label': 'Close',
+                data: { strict_repair_modal_dismiss_for: service_job.id }
 
     .repair-status-widget-modal__body
       %p= t('service_jobs.strict_repair.take_to_work.question')

--- a/app/views/service_jobs/reveal.js.erb
+++ b/app/views/service_jobs/reveal.js.erb
@@ -4,7 +4,7 @@
 // и показываем диалог «Взять в работу? Да / Нет».
 //   «Да» → PATCH repair_status (тот же путь, что и виджет: вытеснение подхватится);
 //   «Нет» → POST dismiss_reveal (закрытие маркера).
-// Обе кнопки и крестик закрывают модалку клиентски; «Да»/«Нет» параллельно шлют UJS-запрос.
+// Все три элемента закрывают модалку клиентски; «Да» шлёт PATCH, «Нет» и крестик — POST dismiss_reveal.
 (function() {
   var sjId = <%= @service_job.id %>;
   $('.strict-repair[data-strict-repair-id="' + sjId + '"]').addClass('strict-repair--revealed');
@@ -18,7 +18,7 @@
   $host.append("<%= j render('take_to_work_modal', service_job: @service_job) %>");
 
   var $modal = $('#strict_repair_modal_' + sjId);
-  $modal.on('click', '[data-strict-repair-modal-close-for], [data-strict-repair-modal-dismiss-for], [data-strict-repair-modal-start-for]', function() {
+  $modal.on('click', '[data-strict-repair-modal-dismiss-for], [data-strict-repair-modal-start-for]', function() {
     $modal.remove();
   });
 })();


### PR DESCRIPTION
The × button only removed the dialog client-side, leaving the RepairAttentionMarker unprocessed (later picked up by the catch-up job) and the content un-veiled. Turn it into the same remote POST to dismiss_reveal as the "No" button, so × now dismisses the marker and re-applies the veil. Drop the now-dead close-for selector branch.