### PR TITLE
fix: remove manual "mark purchase unconfirmed" button

### DIFF
--- a/app/controllers/client_requests_controller.rb
+++ b/app/controllers/client_requests_controller.rb
@@ -56,9 +56,8 @@ class ClientRequestsController < ApplicationController
     end
   end
 
-  # Смена workflow-статуса (в работу / выполнен / не выполнен) ИЛИ ручная
-  # пометка покупки неподтверждённой — обе через одну кнопку-ссылку remote:true.
-  # find_record авторизует через update_status? (action_name → предикат policy).
+  # Смена workflow-статуса (в работу / выполнен / не выполнен) — кнопка-ссылка
+  # remote:true. find_record авторизует через update_status? (action_name → предикат policy).
   def update_status
     @client_request = find_record ClientRequest
 
@@ -101,8 +100,10 @@ class ClientRequestsController < ApplicationController
     nil
   end
 
-  # Разрешаем менять только эти два enum-поля. Кнопки шлют ровно одно из них.
+  # Разрешаем менять только workflow-статус. purchase_check_status выставляется
+  # автоматически 1С-джобой либо вручную через форму редактирования (ввод даты),
+  # но НЕ через эту кнопку — иначе sold_at и статус проверки рассинхронизируются.
   def status_params
-    params.require(:client_request).permit(:status, :purchase_check_status)
+    params.require(:client_request).permit(:status)
   end
 end

--- a/app/views/client_requests/_client_request.html.haml
+++ b/app/views/client_requests/_client_request.html.haml
@@ -32,8 +32,6 @@
           = link_to t('.done_btn'), update_status_client_request_path(cr, client_request: { status: :done }), method: :patch, remote: true, class: 'btn btn-success btn-small'
         - unless cr.failed?
           = link_to t('.failed_btn'), update_status_client_request_path(cr, client_request: { status: :failed }), method: :patch, remote: true, class: 'btn btn-danger btn-small'
-        - unless cr.unconfirmed?
-          = link_to t('.mark_unconfirmed_btn'), update_status_client_request_path(cr, client_request: { purchase_check_status: :unconfirmed }), method: :patch, remote: true, class: 'btn btn-small'
     - if policy(cr).edit?
       = link_to glyph(:pencil), edit_client_request_path(cr), class: 'btn btn-small', title: t('.edit_btn')
     = history_link_to history_client_request_path(cr)

--- a/config/locales/views/client_requests.ru.yml
+++ b/config/locales/views/client_requests.ru.yml
@@ -25,7 +25,6 @@ ru:
       in_progress_btn: В работу
       done_btn: Выполнен
       failed_btn: Не выполнен
-      mark_unconfirmed_btn: Покупка не подтверждена
       edit_btn: Редактировать
     kinds:
       receipt_search: Поиск оригинального чека


### PR DESCRIPTION
The button let anyone with update_status rights flip purchase_check_status back to unconfirmed while leaving sold_at in place. That desynced the two fields: the request showed a confirmed sale date in the UI, but the daily reminder job keys off purchase_check_status (not the date), so requests with a valid date kept sending "не удалось подтвердить покупку" notifications every day.

The button was never in the customer spec — the "special option" described there refers to confirming the date manually (the edit form, ввод даты → confirmed), not un-confirming it. Marking a request unconfirmed is meant to happen automatically when 1C is unavailable or the device isn't found, never by hand.

Also drop :purchase_check_status from status_params so the field can no longer be set via update_status at all (defense in depth) — it now changes only via the 1C job or the edit form. Remove the orphaned mark_unconfirmed_btn locale key.