### PR TITLE
feat: merge client/unlock request menu items into submenu

### DIFF
--- a/app/assets/stylesheets/navbar.css.scss
+++ b/app/assets/stylesheets/navbar.css.scss
@@ -27,3 +27,41 @@
   right: 0;
   z-index: 10;
 }
+
+// Каскадное подменю «Запросы клиентов» в разделе «Сервис».
+// Bootstrap 2.x не несёт .dropdown-submenu глобально — поэтому правила
+// заскоуплены под собственный блок-класс (см. CONTEXT.md про BEM/scope).
+.navbar-requests-submenu {
+  position: relative;
+
+  > .dropdown-menu {
+    top: 0;
+    left: 100%;
+    margin-top: -6px;
+    margin-left: -1px;
+    border-radius: 0 6px 6px 6px;
+    display: none;
+  }
+
+  &:hover > .dropdown-menu {
+    display: block;
+  }
+
+  // стрелка-индикатор «есть вложенность» справа от пункта
+  > a:after {
+    display: block;
+    float: right;
+    width: 0;
+    height: 0;
+    margin-top: 5px;
+    margin-right: -10px;
+    border-width: 5px 0 5px 5px;
+    border-style: solid;
+    border-color: transparent transparent transparent #ccc;
+    content: " ";
+  }
+
+  &:hover > a:after {
+    border-left-color: #fff;
+  }
+}

--- a/app/views/shared/_navbar.html.haml
+++ b/app/views/shared/_navbar.html.haml
@@ -27,8 +27,12 @@
         = menu_item t('orders.link', default: 'Orders'), orders_path if can? :read, Order
         = drop_down_divider
         = menu_item t('clients.link', default: 'Clients'), clients_path
-        = menu_item t('client_requests.index.title'), client_requests_path if policy(ClientRequest).index?
-        = menu_item t('device_unlock_requests.index.title'), device_unlock_requests_path if policy(DeviceUnlockRequest).index?
+        - if policy(ClientRequest).index? || policy(DeviceUnlockRequest).index?
+          %li.dropdown-submenu.navbar-requests-submenu
+            %a{ href: '#', tabindex: '-1' }= t('.client_requests_group')
+            %ul.dropdown-menu
+              = menu_item t('.receipt_search_request'), client_requests_path if policy(ClientRequest).index?
+              = menu_item t('.device_unlock_request'), device_unlock_requests_path if policy(DeviceUnlockRequest).index?
         - if can? :manage, TaskTemplate
           = drop_down_divider
           = menu_item t('task_templates.index.title'), task_templates_path

--- a/config/locales/views/shared.ru.yml
+++ b/config/locales/views/shared.ru.yml
@@ -56,9 +56,11 @@ ru:
     navbar:
       cash_drawer: 'Касса'
       chat: 'Чат'
+      client_requests_group: 'Запросы клиентов'
       completed_quick_orders: 'Выполненные'
       current_quick_orders: 'Текущие'
       data_migration: 'Миграция данных'
+      device_unlock_request: 'Запрос на разблокировку'
       directory: 'Каталог'
       employees: 'Сотрудники'
       favorite: 'Избранное'
@@ -70,6 +72,7 @@ ru:
       quick_orders: 'Быстрый заказ'
       quick_order: 'Быстрый заказ'
       rating: 'Рейтинг'
+      receipt_search_request: 'Запрос на оригинальный чек'
       repair_return: 'Возврат ремонта'
       repair_returns: :service.repair_return.view.title.index
       reports: 'Отчёты'


### PR DESCRIPTION
Customer asked to declutter the Service navbar: the two adjacent items "Запросы клиентов" (receipt search) and "Запросы на разблокировку" are collapsed into one cascading submenu "Запросы клиентов" that opens on hover with two children — one per request type.

- Markup follows the existing submenu pattern in the repair status widget (li.dropdown-submenu + nested ul.dropdown-menu), since the twitter-bootstrap-rails drop_down_submenu helper renders an empty href that reloads the page on a parent click.
- CSS is scoped under .navbar-requests-submenu, not the generic .dropdown-submenu, so hover behavior can't leak into other menus (Bootstrap 2.x ships no global submenu styles in this project).
- Parent li renders if either policy(...).index? passes; each child stays gated by its own policy, so partial-access users see a non-empty submenu rather than all-or-nothing.