### PR TITLE
feat: add archiving for kanban boards

### DIFF
--- a/app/controllers/kanban/boards_controller.rb
+++ b/app/controllers/kanban/boards_controller.rb
@@ -1,10 +1,15 @@
 module Kanban
   class BoardsController < ApplicationController
-    before_action :set_board, only: %i[edit update destroy sorted archived]
+    before_action :set_board, only: %i[edit update destroy sorted archived archive unarchive]
 
     def index
       authorize Board
-      @boards = Board.order(:id)
+      @boards = Board.active.order(:id)
+    end
+
+    def archived_boards
+      authorize Board
+      @boards = Board.archived.order(:id)
     end
 
     def show
@@ -66,6 +71,16 @@ module Kanban
 
     def archived
       @archived_cards = @board.archived_cards
+    end
+
+    def archive
+      @board.archive!
+      redirect_to kanban_boards_url, notice: t('.archived')
+    end
+
+    def unarchive
+      @board.unarchive!
+      redirect_to archived_boards_kanban_boards_url, notice: t('.unarchived')
     end
 
     private

--- a/app/models/kanban/board.rb
+++ b/app/models/kanban/board.rb
@@ -1,4 +1,7 @@
 class Kanban::Board < ApplicationRecord
+  scope :active, -> { where(archived: false) }
+  scope :archived, -> { where(archived: true) }
+
   has_many :columns, -> { ordered }, class_name: 'Kanban::Column', dependent: :destroy
   belongs_to :telegram_chat, optional: true
   has_and_belongs_to_many :managers,
@@ -26,5 +29,13 @@ class Kanban::Board < ApplicationRecord
                 .joins(:column)
                 .where(kanban_columns: {board_id: id})
                 .where(archived: true)
+  end
+
+  def archive!
+    update!(archived: true)
+  end
+
+  def unarchive!
+    update!(archived: false)
   end
 end

--- a/app/policies/kanban/board_policy.rb
+++ b/app/policies/kanban/board_policy.rb
@@ -15,5 +15,17 @@ module Kanban
     def archived?
       read?
     end
+
+    def archived_boards?
+      read?
+    end
+
+    def archive?
+      manage?
+    end
+
+    def unarchive?
+      manage?
+    end
   end
 end

--- a/app/views/kanban/boards/archived_boards.html.erb
+++ b/app/views/kanban/boards/archived_boards.html.erb
@@ -1,26 +1,25 @@
 <div class="page-header">
   <h2>
+    <%= link_back_to kanban_boards_path %>
     <%= t '.title' %>
-
-    <% if can? :create, Kanban::Board %>
-      <%= link_to t('kanban.boards.index.add_board'), new_kanban_board_path, class: 'btn btn-success' %>
-    <% end %>
-
-    <%= link_to t('.archived_boards'), archived_boards_kanban_boards_path, class: 'btn' %>
   </h2>
 </div>
 
 <div class="row-fluid">
+  <% if @boards.empty? %>
+    <p class="muted"><%= t '.empty' %></p>
+  <% end %>
+
   <% @boards.each do |board| %>
     <% if can? :show, board %>
       <div class="span2 text-center mobile-full">
         <%= link_to kanban_board_path(board) do %>
           <div class="thumbnail" style="background-color: <%= board.background || '#ffffff' %>;">
             <h3><%= board.name %></h3>
-            <span class="help-tooltip" data-toggle="tooltip" data-placement="right" title="<%= board.outer_annotation %>">
-              <i class="fa fa-question-circle"></i>
-            </span>
           </div>
+        <% end %>
+        <% if can?(:unarchive, board) %>
+          <%= link_to t('.unarchive'), unarchive_kanban_board_path(board), method: :patch, class: 'btn btn-small btn-success' %>
         <% end %>
       </div>
     <% end %>

--- a/app/views/kanban/boards/show.html.erb
+++ b/app/views/kanban/boards/show.html.erb
@@ -18,6 +18,11 @@
       <% end %>
       <%= link_to(icon(:edit), edit_kanban_board_path(@board), class: 'btn btn-small') if can?(:edit, @board) %>
       <%= link_to_destroy_small(@board) if can?(:destroy, @board) %>
+      <% if can?(:archive, @board) %>
+        <%= link_to icon_tag(:archive), archive_kanban_board_path(@board), method: :patch,
+                    class: 'btn btn-small', title: t('.archive_board'),
+                    data: { confirm: t('.archive_confirm') } %>
+      <% end %>
       <%= link_to 'Архивные карточки', archived_kanban_board_path(@board), class: 'btn btn-submit' %>
     </h2>
 

--- a/config/locales/kanban.ru.yml
+++ b/config/locales/kanban.ru.yml
@@ -12,7 +12,14 @@ ru:
       index:
         title: 'Канбан Доски'
         add_board: 'Добавить Доску'
+        archived_boards: 'Архив досок'
+      archived_boards:
+        title: 'Архивные доски'
+        empty: 'Архивных досок нет'
+        unarchive: 'Вернуть из архива'
       show:
+        archive_board: 'В архив'
+        archive_confirm: 'Убрать доску в архив?'
         choose_sorting_type: 'Выберите вариант сортировки:'
         classic_sort: 'Классическая'
         deadline_desc_sort: 'Сроки по убыванию'
@@ -24,6 +31,8 @@ ru:
       created: 'Доска создана'
       updated: 'Доска изменена'
       destroyed: 'Доска удалена'
+      archived: 'Доска убрана в архив'
+      unarchived: 'Доска возвращена из архива'
     columns:
       edit:
         title: 'Редактирование Колонки'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -526,6 +526,9 @@ Rails.application.routes.draw do
       end
       get :sorted, on: :member, defaults: {format: :js}
       get :archived, on: :member
+      patch :archive, on: :member
+      patch :unarchive, on: :member
+      get :archived_boards, on: :collection
     end
   end
 

--- a/db/migrate/20260626120000_add_archived_to_kanban_boards.rb
+++ b/db/migrate/20260626120000_add_archived_to_kanban_boards.rb
@@ -1,0 +1,6 @@
+class AddArchivedToKanbanBoards < ActiveRecord::Migration[5.1]
+  def change
+    add_column :kanban_boards, :archived, :boolean, default: false, null: false
+    add_index :kanban_boards, :archived
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20260625120000) do
+ActiveRecord::Schema.define(version: 20260626120000) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -865,7 +865,9 @@ ActiveRecord::Schema.define(version: 20260625120000) do
     t.text "inner_annotation"
     t.integer "auto_add_department_ids", default: [], array: true
     t.bigint "telegram_chat_id"
+    t.boolean "archived", default: false, null: false
     t.index ["allowed_user_ids"], name: "index_kanban_boards_on_allowed_user_ids"
+    t.index ["archived"], name: "index_kanban_boards_on_archived"
     t.index ["auto_add_department_ids"], name: "index_kanban_boards_on_auto_add_department_ids", using: :gin
     t.index ["telegram_chat_id"], name: "index_kanban_boards_on_telegram_chat_id"
   end


### PR DESCRIPTION
Boards can now be archived to hide them from the main list without touching their columns or cards — unarchiving restores everything intact. This is separate from card archiving, which already existed.

Add a boolean `archived` column to kanban_boards (with index) and explicit `active`/`archived` scopes on Kanban::Board. Deliberately avoid a default_scope so `show` and `archived_cards` can still load an archived board via find_by(id:).

New member actions archive/unarchive (PATCH, superadmin-only via BoardPolicy#manage?) and a collection action archived_boards listing archived boards. The collection route is declared before the :id show route so /kanban/boards/archived_boards is not swallowed as a show.

UI: "В архив" button on the board page next to delete (with confirm), "Архив досок" link on the index, and an archived-boards page with an "unarchive" button per board.