### PR TITLE
feat: expose per-department repair availability in repair API

### DIFF
--- a/app/api/entities/repair_department_entity.rb
+++ b/app/api/entities/repair_department_entity.rb
@@ -1,0 +1,6 @@
+class Entities::RepairDepartmentEntity < Grape::Entity
+  expose :short_name
+  expose :has_repair do |department, _options|
+    department.participates_in_repair_services?
+  end
+end

--- a/app/api/repair_api.rb
+++ b/app/api/repair_api.rb
@@ -21,5 +21,6 @@ class RepairApi < Grape::API
     end
 
     present :groups, repair_groups, with: Entities::RepairGroupEntity
+    present :departments, Department.real, with: Entities::RepairDepartmentEntity
   end
 end

--- a/app/views/departments/form.html.haml
+++ b/app/views/departments/form.html.haml
@@ -11,7 +11,7 @@
   = f.input :ip_network
   = f.input :url
   = f.input :printer
-  = f.input :participates_in_repair_services, as: :boolean
+  = f.input :participates_in_repair_services, as: :boolean, hint: 'Если снять — филиал попадёт в выгрузку цен помеченным как «без ремонта», сайт покажет, что ремонта здесь нет.'
   = f.input :strict_repair, as: :boolean
   = f.input :archive
   .form-actions


### PR DESCRIPTION
The repair_services feed previously filtered out departments with participates_in_repair_services=false, so API clients could not tell "branch does not do repairs" apart from "branch does not exist". The site had no way to render "no repair at this branch".

Add a top-level `departments` list to GET /api/v1/repair_services exposing every real department with a `has_repair` flag (mapped from participates_in_repair_services). The `prices` hash is left untouched (participating branches only), so existing clients keep working and the new key is purely additive.

Also add a form hint on the department checkbox so admins understand that unchecking it now surfaces the branch in the feed as "no repair" rather than hiding it.