### PR TITLE
feat: notify superadmins on unlock request creation, include author

### DIFF
--- a/app/controllers/device_unlock_requests_controller.rb
+++ b/app/controllers/device_unlock_requests_controller.rb
@@ -43,8 +43,7 @@ class DeviceUnlockRequestsController < ApplicationController
     @device_unlock_request.department = current_user.department
 
     if @device_unlock_request.save
-      # Событийное in-app уведомление суперадминам о новом запросе (план §6).
-      # Синхронно, без джобы — как GlassStickingController#notify.
+      # In-app уведомление суперадминам о новом запросе — синхронно, без джобы.
       @device_unlock_request.notify_about_creation
       redirect_to device_unlock_requests_path, notice: t('.created')
     else
@@ -117,8 +116,7 @@ class DeviceUnlockRequestsController < ApplicationController
     @notified_count = ids.size # для inline-flash во вью (sent vs moved)
     if ids.any?
       recipients = User.where(id: ids)
-      # Пикер — единственный сценарий, где автора-оператора исключаем: он
-      # выбирает получателей руками и себя в списке видеть не должен (реш. 02.07).
+      # Оператор сам выбирает получателей в пикере — себя из рассылки исключаем.
       @device_unlock_request.notify(
         recipients,
         @device_unlock_request.status_notification_message,

--- a/app/controllers/device_unlock_requests_controller.rb
+++ b/app/controllers/device_unlock_requests_controller.rb
@@ -43,6 +43,9 @@ class DeviceUnlockRequestsController < ApplicationController
     @device_unlock_request.department = current_user.department
 
     if @device_unlock_request.save
+      # Событийное in-app уведомление суперадминам о новом запросе (план §6).
+      # Синхронно, без джобы — как GlassStickingController#notify.
+      @device_unlock_request.notify_about_creation
       redirect_to device_unlock_requests_path, notice: t('.created')
     else
       render :new
@@ -114,10 +117,13 @@ class DeviceUnlockRequestsController < ApplicationController
     @notified_count = ids.size # для inline-flash во вью (sent vs moved)
     if ids.any?
       recipients = User.where(id: ids)
+      # Пикер — единственный сценарий, где автора-оператора исключаем: он
+      # выбирает получателей руками и себя в списке видеть не должен (реш. 02.07).
       @device_unlock_request.notify(
         recipients,
         @device_unlock_request.status_notification_message,
-        url: @device_unlock_request.show_url
+        url: @device_unlock_request.show_url,
+        exclude_current_user: true
       )
     end
 

--- a/app/models/device_unlock_request.rb
+++ b/app/models/device_unlock_request.rb
@@ -50,15 +50,12 @@ class DeviceUnlockRequest < ApplicationRecord
     comments.newest.first
   end
 
-  # Ядро рассылки in-app уведомлений (план §11.1): персональный Notification +
-  # ActionCable-broadcast каждому получателю. Получателей передаём аргументом,
-  # НЕ через notification_recipients — иначе комментарии потянули бы уведомления
-  # (§2.4). На этот метод обопрутся Циклы 11–12 (ручной пикер получателей).
+  # Рассылает персональный Notification + ActionCable-broadcast каждому получателю.
+  # Получателей передаём аргументом, а не читаем из notification_recipients: если
+  # бы модель отвечала на этот метод, CommentsController#create_notifications начал
+  # бы слать уведомления ещё и на каждый комментарий.
   #
-  # exclude_current_user (реш. заказчика 02.07): по умолчанию НЕ исключаем автора
-  # действия — создание и смена статуса шлют колокольчик и самому инициатору.
-  # Явный true передаёт только пикер (notify_approval): там оператор выбирает
-  # получателей руками и себя в списке видеть не должен.
+  # exclude_current_user: при true выкидывает из получателей текущего юзера.
   def notify(recipients, message, url:, exclude_current_user: false)
     Array(recipients)
       .reject { |recipient| exclude_current_user && recipient.id == User.current&.id }
@@ -73,10 +70,9 @@ class DeviceUnlockRequest < ApplicationRecord
       end
   end
 
-  # Уведомление суперадминам о НОВОМ запросе (план §6). Автора НЕ исключаем
-  # (реш. заказчика 02.07): суперадмин, создавший запрос сам, тоже получает
-  # колокольчик. Ссылка ведёт на список — новый всплывает наверх (scope :recent),
-  # в отличие от §11-статусов, где ссылка на сам запрос (show).
+  # Ссылка ведёт на список (index_url), а не на сам запрос: новый всплывает
+  # наверх по scope :recent. exclude_current_user не передаём, поэтому автор,
+  # если он суперадмин, тоже попадает в получателей.
   def notify_about_creation
     notify(User.superadmins.active, creation_notification_message, url: index_url)
   end
@@ -89,9 +85,7 @@ class DeviceUnlockRequest < ApplicationRecord
     Rails.application.routes.url_helpers.device_unlock_requests_path
   end
 
-  # Авто-уведомление суперадминам при переходе в approved/client_declined
-  # (план §11.2). Ссылка ведёт на сам запрос (show), в отличие от §6. Автора
-  # НЕ исключаем (реш. заказчика 02.07) — см. notify.
+  # Ссылка ведёт на сам запрос (show_url), а не на список.
   def notify_superadmins_of_status
     notify(User.superadmins.active, status_notification_message, url: show_url)
   end

--- a/app/models/device_unlock_request.rb
+++ b/app/models/device_unlock_request.rb
@@ -51,14 +51,17 @@ class DeviceUnlockRequest < ApplicationRecord
   end
 
   # Ядро рассылки in-app уведомлений (план §11.1): персональный Notification +
-  # ActionCable-broadcast каждому получателю. Автора действия (User.current)
-  # исключаем всегда (реш. §11.6) — суперадмин, сам сменивший статус, себе
-  # колокольчик не шлёт. Получателей передаём аргументом, НЕ через
-  # notification_recipients — иначе комментарии потянули бы уведомления (§2.4).
-  # На этот метод обопрутся Циклы 11–12 (ручной пикер получателей).
-  def notify(recipients, message, url:)
+  # ActionCable-broadcast каждому получателю. Получателей передаём аргументом,
+  # НЕ через notification_recipients — иначе комментарии потянули бы уведомления
+  # (§2.4). На этот метод обопрутся Циклы 11–12 (ручной пикер получателей).
+  #
+  # exclude_current_user (реш. заказчика 02.07): по умолчанию НЕ исключаем автора
+  # действия — создание и смена статуса шлют колокольчик и самому инициатору.
+  # Явный true передаёт только пикер (notify_approval): там оператор выбирает
+  # получателей руками и себя в списке видеть не должен.
+  def notify(recipients, message, url:, exclude_current_user: false)
     Array(recipients)
-      .reject { |recipient| recipient.id == User.current&.id }
+      .reject { |recipient| exclude_current_user && recipient.id == User.current&.id }
       .each do |recipient|
         notification = Notification.create!(
           user: recipient,
@@ -70,8 +73,25 @@ class DeviceUnlockRequest < ApplicationRecord
       end
   end
 
+  # Уведомление суперадминам о НОВОМ запросе (план §6). Автора НЕ исключаем
+  # (реш. заказчика 02.07): суперадмин, создавший запрос сам, тоже получает
+  # колокольчик. Ссылка ведёт на список — новый всплывает наверх (scope :recent),
+  # в отличие от §11-статусов, где ссылка на сам запрос (show).
+  def notify_about_creation
+    notify(User.superadmins.active, creation_notification_message, url: index_url)
+  end
+
+  def creation_notification_message
+    "Создан новый запрос на разблокировку: #{client.full_name}"
+  end
+
+  def index_url
+    Rails.application.routes.url_helpers.device_unlock_requests_path
+  end
+
   # Авто-уведомление суперадминам при переходе в approved/client_declined
-  # (план §11.2). Ссылка ведёт на сам запрос (show), в отличие от §6.
+  # (план §11.2). Ссылка ведёт на сам запрос (show), в отличие от §6. Автора
+  # НЕ исключаем (реш. заказчика 02.07) — см. notify.
   def notify_superadmins_of_status
     notify(User.superadmins.active, status_notification_message, url: show_url)
   end


### PR DESCRIPTION
Reintroduce the in-app notification on DeviceUnlockRequest creation (orphaned in branch 170, never merged). Reuse the existing #notify path instead of the old standalone loop.

Per customer decision (02.07), the action author is no longer excluded: both creation and status-change notifications now reach the initiating superadmin too. Author exclusion is kept only for the approval picker, which passes the new exclude_current_user: true flag.

Notifications are sent synchronously in the request cycle (no job), matching GlassStickingController#notify.