### PR TITLE
fix: sort topbar notifications popover by created_at desc

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -30,7 +30,7 @@ class NotificationsController < ApplicationController
     authorize Notification
 
     scope = current_user.notifications.not_closed
-    @notifications = scope.page(params[:page])
+    @notifications = scope.order(created_at: :desc).page(params[:page])
     # Флаги для цвета иконки в topbar: синий — только наклейка стекла,
     # красный — только прочие, красно-синий — и то, и другое.
     @has_glass = scope.glass_sticking.exists?


### PR DESCRIPTION
The user_notifications action (topbar envelope popover) had no explicit ORDER, so it relied on Postgres default row order — effectively oldest on top, newest at the bottom. This contradicted both the "All notifications" modal (index action, ordered created_at DESC) and the documented "Always created_at DESC" behavior.

Add .order(created_at: :desc) before .page so the newest notification shows on top, consistently on first load and on realtime re-render via UserNotificationChannel.