### PR TITLE
feat: add kanban board copy with structure duplication

### DIFF
--- a/app/controllers/kanban/boards_controller.rb
+++ b/app/controllers/kanban/boards_controller.rb
@@ -1,6 +1,6 @@
 module Kanban
   class BoardsController < ApplicationController
-    before_action :set_board, only: %i[edit update destroy sorted archived archive unarchive]
+    before_action :set_board, only: %i[edit update destroy sorted archived copy archive unarchive]
 
     def index
       authorize Board
@@ -71,6 +71,13 @@ module Kanban
 
     def archived
       @archived_cards = @board.archived_cards
+    end
+
+    def copy
+      return render 'shared/show_modal_form' if request.get?
+
+      @new_board = @board.duplicate_structure(params[:name], author: current_user)
+      flash[:notice] = t('.copied') if @new_board.persisted? && @new_board.errors.empty?
     end
 
     def archive

--- a/app/models/kanban/board.rb
+++ b/app/models/kanban/board.rb
@@ -38,4 +38,29 @@ class Kanban::Board < ApplicationRecord
   def unarchive!
     update!(archived: false)
   end
+
+  # Creates a fresh board with the given name replicating only the structure —
+  # columns and cards (name + content). Comments, positions, deadlines, photos,
+  # managers and access are intentionally not copied: the copy is a blank
+  # template meant to be re-assigned from scratch. Runs in a transaction so a
+  # failure anywhere leaves no half-built board. On validation failure (most
+  # likely a blank or duplicate name) the returned board carries the errors and
+  # is not persisted.
+  def duplicate_structure(new_name, author:)
+    new_board = Kanban::Board.new(name: new_name)
+    begin
+      transaction do
+        new_board.save!
+        columns.ordered.each do |column|
+          new_column = new_board.columns.create!(name: column.name)
+          column.cards.ordered.each do |card|
+            new_column.cards.create!(name: card.name, content: card.content, author: author)
+          end
+        end
+      end
+    rescue ActiveRecord::RecordInvalid => e
+      new_board.errors.add(:base, e.message) if new_board.errors.empty?
+    end
+    new_board
+  end
 end

--- a/app/policies/kanban/board_policy.rb
+++ b/app/policies/kanban/board_policy.rb
@@ -20,6 +20,10 @@ module Kanban
       read?
     end
 
+    def copy?
+      manage?
+    end
+
     def archive?
       manage?
     end

--- a/app/views/kanban/boards/_modal_form_content.html.haml
+++ b/app/views/kanban/boards/_modal_form_content.html.haml
@@ -1,0 +1,16 @@
+.modal-header
+  = button_to_close_modal
+  %h3= t('kanban.boards.copy.title')
+
+= form_with url: copy_kanban_board_path(@board), method: :post, local: false, id: 'copy_board_form' do |f|
+  .modal-body
+    - if @new_board&.errors&.any?
+      .alert.alert-error= @new_board.errors.full_messages.to_sentence
+    .control-group
+      = f.label :name, t('kanban.boards.copy.name_label'), class: 'control-label'
+      .controls
+        = f.text_field :name, class: 'input-xlarge', required: true, value: @new_board&.name
+
+  .modal-footer
+    = f.submit t('kanban.boards.copy.submit'), class: 'btn btn-primary'
+    = link_to t('helpers.links.close'), '#', 'data-dismiss' => 'modal', class: 'btn'

--- a/app/views/kanban/boards/copy.js.erb
+++ b/app/views/kanban/boards/copy.js.erb
@@ -1,0 +1,6 @@
+<% if @new_board.persisted? && @new_board.errors.empty? %>
+  $('#modal_form').modal('hide');
+  window.location = '<%= kanban_board_path(@new_board) %>';
+<% else %>
+  $('#modal_form').html('<%= j render("modal_form_content") %>');
+<% end %>

--- a/app/views/kanban/boards/show.html.erb
+++ b/app/views/kanban/boards/show.html.erb
@@ -24,6 +24,9 @@
                     data: { confirm: t('.archive_confirm') } %>
       <% end %>
       <%= link_to 'Архивные карточки', archived_kanban_board_path(@board), class: 'btn btn-submit' %>
+      <% if can?(:copy, @board) %>
+        <%= link_to t('.copy_board'), copy_kanban_board_path(@board), remote: true, class: 'btn btn-submit' %>
+      <% end %>
     </h2>
 
     <div class="kanban-board-description">

--- a/config/locales/kanban.ru.yml
+++ b/config/locales/kanban.ru.yml
@@ -20,6 +20,7 @@ ru:
       show:
         archive_board: 'В архив'
         archive_confirm: 'Убрать доску в архив?'
+        copy_board: 'Скопировать доску'
         choose_sorting_type: 'Выберите вариант сортировки:'
         classic_sort: 'Классическая'
         deadline_desc_sort: 'Сроки по убыванию'
@@ -28,11 +29,16 @@ ru:
         manager_person: "Ответственный %{name}"
         add_card: 'Добавить Карточку'
         add_column: 'Добавить Колонку'
+      copy:
+        title: 'Копирование доски'
+        name_label: 'Название новой доски'
+        submit: 'Создать копию'
       created: 'Доска создана'
       updated: 'Доска изменена'
       destroyed: 'Доска удалена'
       archived: 'Доска убрана в архив'
       unarchived: 'Доска возвращена из архива'
+      copied: 'Доска скопирована'
     columns:
       edit:
         title: 'Редактирование Колонки'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -536,6 +536,8 @@ Rails.application.routes.draw do
       end
       get :sorted, on: :member, defaults: {format: :js}
       get :archived, on: :member
+      get :copy, on: :member
+      post :copy, on: :member
       patch :archive, on: :member
       patch :unarchive, on: :member
       get :archived_boards, on: :collection


### PR DESCRIPTION
Add "Скопировать доску" button (superadmin only) on the board page. It opens a Bootstrap modal asking for the new board name and creates a fresh board replicating the structure — columns (ordered) and cards (name + content). Comments, positions, deadlines, photos, managers and access are intentionally not copied: the copy is a blank template for re-assignment year over year. Duplication runs in a transaction; a duplicate/blank name re-renders the modal with the validation error.