### PR TITLE
feat: add per-user default order filters (branches + statuses)

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -266,8 +266,13 @@ class OrdersController < ApplicationController
       p[:department_ids].reject! { |e| e.to_s.empty? }
       p[:statuses].reject! { |e| e.to_s.empty? }
       if request.format.html?
-        p[:department_ids] = [current_department&.id] if p[:department_ids].blank? && current_department
-        p[:statuses] = %w[current on_the_way done] if p[:statuses].blank?
+        settings = current_user&.user_settings
+        if p[:department_ids].blank?
+          p[:department_ids] = settings&.default_order_department_ids.presence || [current_department&.id].compact
+        end
+        if p[:statuses].blank?
+          p[:statuses] = settings&.default_order_statuses.presence || %w[current on_the_way done]
+        end
       end
     end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -337,7 +337,7 @@ class UsersController < ApplicationController
   end
 
   def user_settings_params
-    params.require(:user_settings).permit(:fixed_main_menu, :auto_department_detection, :receive_location_task_notifications, :receive_glass_sticking_notifications)
+    params.require(:user_settings).permit(:fixed_main_menu, :auto_department_detection, :receive_location_task_notifications, :receive_glass_sticking_notifications, default_order_department_ids: [], default_order_statuses: [])
   end
 
   def update_self_params

--- a/app/models/user_settings.rb
+++ b/app/models/user_settings.rb
@@ -5,4 +5,6 @@ class UserSettings < ApplicationRecord
   attribute :auto_department_detection, :boolean, default: true
   attribute :receive_location_task_notifications, :boolean, default: true
   attribute :receive_glass_sticking_notifications, :boolean, default: true
+  attribute :default_order_department_ids, :integer, array: true, default: []
+  attribute :default_order_statuses, :string, array: true, default: []
 end

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -319,6 +319,18 @@
             = f.input :auto_department_detection
             = f.input :receive_location_task_notifications
             = f.input :receive_glass_sticking_notifications
+            %h4 Работа с заказами
+            %small.text-muted По умолчанию — эти филиалы и статусы подставятся при заходе в «Заказы»
+            = f.input :default_order_department_ids,
+              label: 'Филиалы по умолчанию',
+              as: :select,
+              input_html: { multiple: true },
+              collection: Department.all.order(:name)
+            = f.input :default_order_statuses,
+              label: 'Статусы по умолчанию',
+              as: :select,
+              input_html: { multiple: true },
+              collection: Order::NEW_STATUSES.map { |s| [t("orders.statuses.#{s}"), s] }
             = submit_button f
 
       #notifications_tab.tab-pane

--- a/db/migrate/20260703200350_add_order_defaults_to_user_settings.rb
+++ b/db/migrate/20260703200350_add_order_defaults_to_user_settings.rb
@@ -1,0 +1,6 @@
+class AddOrderDefaultsToUserSettings < ActiveRecord::Migration[5.1]
+  def change
+    add_column :user_settings, :default_order_department_ids, :integer, array: true, default: []
+    add_column :user_settings, :default_order_statuses, :string, array: true, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20260702170837) do
+ActiveRecord::Schema.define(version: 20260703200350) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -2408,6 +2408,8 @@ ActiveRecord::Schema.define(version: 20260702170837) do
     t.datetime "updated_at", null: false
     t.boolean "receive_location_task_notifications", default: true, null: false
     t.boolean "receive_glass_sticking_notifications", default: true, null: false
+    t.integer "default_order_department_ids", default: [], array: true
+    t.string "default_order_statuses", default: [], array: true
     t.index ["user_id"], name: "index_user_settings_on_user_id"
   end
 


### PR DESCRIPTION
Employees can now pick default branches and statuses in their profile settings tab ("Работа с заказами → По умолчанию"). On a fresh visit to /orders these values pre-fill the branch and status filters instead of the hardcoded department + default statuses.

Stored as Postgres array columns on user_settings; empty selection falls back to the previous behaviour, so existing users are unaffected without any data backfill.