### PR TITLE
style: enlarge navbar brand logo to 50px

### DIFF
--- a/app/assets/stylesheets/_bootstrap_and_overrides.css.scss
+++ b/app/assets/stylesheets/_bootstrap_and_overrides.css.scss
@@ -58,13 +58,13 @@ body {
 }
 
 .navbar-static-top {
-  margin-top: 40px;
+  margin-top: 42px;
   a.brand {
     text-decoration: none;
     margin: 0;
     padding: 1px 0;
     img {
-      height: 38px;
+      height: 50px;
       padding-right: 4px;
     }
   }

--- a/app/assets/stylesheets/navbar.css.scss
+++ b/app/assets/stylesheets/navbar.css.scss
@@ -23,7 +23,7 @@
 
 .fixed-menu {
   position: sticky;
-  top: 38px;
+  top: 42px;
   right: 0;
   z-index: 10;
 }


### PR DESCRIPTION
Bump the brand image height from 38px to 50px for better visibility. Adjust navbar margin-top (40->42px) and the sticky main-menu offset (38->42px) so the taller logo stays aligned with the fixed topbar and the sticky menu keeps the correct scroll threshold.