### PR TITLE
feat: show device IMEI in client and unlock request tables

### DIFF
--- a/app/views/client_requests/_client_request.html.haml
+++ b/app/views/client_requests/_client_request.html.haml
@@ -12,6 +12,9 @@
     - if cr.item.serial_number.present?
       %br
       %small.muted= cr.item.serial_number
+    - if cr.item.imei.present?
+      %br
+      %small.muted= "IMEI: #{cr.item.imei}"
   %td.client-requests__purchase-cell
     - if cr.sold_at.present?
       %span{ class: "client-requests__usage--#{cr.usage_bucket.to_s.tr('_', '-')}" }

--- a/app/views/device_unlock_requests/_device_unlock_request.html.haml
+++ b/app/views/device_unlock_requests/_device_unlock_request.html.haml
@@ -14,6 +14,9 @@
     - if r.item.serial_number.present?
       %br
       %small.muted= r.item.serial_number
+    - if r.item.imei.present?
+      %br
+      %small.muted= "IMEI: #{r.item.imei}"
   %td= r.reason
   %td.device-unlock-requests__comment-cell
     - if r.last_comment


### PR DESCRIPTION
Add IMEI as a third line under device name and serial number in the shared request-row partials, so it appears in both request features (client requests, device unlock requests) across index, show and the client card. Gated on presence — devices without an IMEI feature are unaffected. IMEI is labeled to disambiguate it from the serial number.