### PR TITLE
feat: add per-section default order filters (spare/non-spare/archive)

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -267,14 +267,45 @@ class OrdersController < ApplicationController
       p[:statuses].reject! { |e| e.to_s.empty? }
       if request.format.html?
         settings = current_user&.user_settings
+        section  = detect_order_section
         if p[:department_ids].blank?
-          p[:department_ids] = settings&.default_order_department_ids.presence || [current_department&.id].compact
+          p[:department_ids] = section_default(settings, section, :department_ids) ||
+                               settings&.default_order_department_ids.presence ||
+                               [current_department&.id].compact
         end
         if p[:statuses].blank?
-          p[:statuses] = settings&.default_order_statuses.presence || %w[current on_the_way done]
+          p[:statuses] = section_default(settings, section, :statuses) ||
+                         fallback_statuses(settings, section)
         end
       end
     end
+  end
+
+  # Which orders tab the current request belongs to, mirroring the scoping in
+  # #index but adding archive (identified by the top-level status param).
+  # @return [String, nil] section key or nil for the plain landing view
+  def detect_order_section
+    return 'archive' if params[:status] == 'archive'
+    return 'spare_parts' if current_user&.technician? || params[:kind] == 'spare_parts'
+    return 'not_spare_parts' if current_user&.marketing? || params[:kind] == 'not_spare_parts'
+
+    nil
+  end
+
+  # Section-scoped default (point 2), or nil when unset / no section.
+  def section_default(settings, section, kind)
+    return nil unless settings && section
+
+    settings.public_send("default_#{section}_#{kind}").presence
+  end
+
+  # Status fallback once the section-scoped value is empty. Archive deliberately
+  # skips the general default: a general "current/done" set would hide archived
+  # orders and make the Archive tab pointless.
+  def fallback_statuses(settings, section)
+    return %w[archive] if section == 'archive'
+
+    settings&.default_order_statuses.presence || %w[current on_the_way done]
   end
 
   def order_params

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -337,7 +337,11 @@ class UsersController < ApplicationController
   end
 
   def user_settings_params
-    params.require(:user_settings).permit(:fixed_main_menu, :auto_department_detection, :receive_location_task_notifications, :receive_glass_sticking_notifications, default_order_department_ids: [], default_order_statuses: [])
+    section_defaults = UserSettings::SECTIONS.each_with_object({}) do |section, acc|
+      acc[:"default_#{section}_department_ids"] = []
+      acc[:"default_#{section}_statuses"] = []
+    end
+    params.require(:user_settings).permit(:fixed_main_menu, :auto_department_detection, :receive_location_task_notifications, :receive_glass_sticking_notifications, default_order_department_ids: [], default_order_statuses: [], **section_defaults)
   end
 
   def update_self_params

--- a/app/models/user_settings.rb
+++ b/app/models/user_settings.rb
@@ -1,4 +1,9 @@
 class UserSettings < ApplicationRecord
+  # Orders page sections a user can pre-filter. Single source of truth:
+  # migration, strong params, the settings form and the orders controller
+  # all iterate over this list, so adding a tab means one line here + columns.
+  SECTIONS = %w[spare_parts not_spare_parts archive].freeze
+
   belongs_to :user
 
   attribute :fixed_main_menu, :boolean, default: false
@@ -7,4 +12,31 @@ class UserSettings < ApplicationRecord
   attribute :receive_glass_sticking_notifications, :boolean, default: true
   attribute :default_order_department_ids, :integer, array: true, default: []
   attribute :default_order_statuses, :string, array: true, default: []
+
+  SECTIONS.each do |section|
+    attribute :"default_#{section}_department_ids", :integer, array: true, default: []
+    attribute :"default_#{section}_statuses", :string, array: true, default: []
+  end
+
+  # Every order-default array column, so normalization covers point-1 globals
+  # and all section-scoped columns without repetition.
+  ORDER_DEFAULT_ATTRS = (['default_order'] + SECTIONS.map { |s| "default_#{s}" })
+                        .flat_map { |p| ["#{p}_department_ids", "#{p}_statuses"] }
+                        .freeze
+
+  before_validation :strip_blank_order_defaults
+
+  private
+
+  # simple_form prepends a hidden blank field before each multi-select, so an
+  # untouched list arrives as [""] / [nil]. Left as-is that reads as "present"
+  # and shorts out the layered fallback in OrdersController, so we compact it.
+  def strip_blank_order_defaults
+    ORDER_DEFAULT_ATTRS.each do |attr|
+      value = public_send(attr)
+      next unless value.is_a?(Array)
+
+      public_send("#{attr}=", value.reject { |e| e.to_s.strip.empty? })
+    end
+  end
 end

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -331,6 +331,20 @@
               as: :select,
               input_html: { multiple: true },
               collection: Order::NEW_STATUSES.map { |s| [t("orders.statuses.#{s}"), s] }
+            %small.text-muted Ниже — отдельные наборы для вкладок «Запчасти», «Не запчасти» и «Архив». Если пусто, действует общий набор выше.
+            - UserSettings::SECTIONS.each do |section|
+              - section_title = section == 'archive' ? t('orders.statuses.archive') : t("orders.#{section}")
+              %h5= section_title
+              = f.input :"default_#{section}_department_ids",
+                label: "Филиалы — #{section_title}",
+                as: :select,
+                input_html: { multiple: true },
+                collection: Department.all.order(:name)
+              = f.input :"default_#{section}_statuses",
+                label: "Статусы — #{section_title}",
+                as: :select,
+                input_html: { multiple: true },
+                collection: Order::NEW_STATUSES.map { |s| [t("orders.statuses.#{s}"), s] }
             = submit_button f
 
       #notifications_tab.tab-pane

--- a/db/migrate/20260706204851_add_section_order_defaults_to_user_settings.rb
+++ b/db/migrate/20260706204851_add_section_order_defaults_to_user_settings.rb
@@ -1,0 +1,8 @@
+class AddSectionOrderDefaultsToUserSettings < ActiveRecord::Migration[5.1]
+  def change
+    %w[spare_parts not_spare_parts archive].each do |section|
+      add_column :user_settings, :"default_#{section}_department_ids", :integer, array: true, default: []
+      add_column :user_settings, :"default_#{section}_statuses", :string, array: true, default: []
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20260703200350) do
+ActiveRecord::Schema.define(version: 20260706204851) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -2410,6 +2410,12 @@ ActiveRecord::Schema.define(version: 20260703200350) do
     t.boolean "receive_glass_sticking_notifications", default: true, null: false
     t.integer "default_order_department_ids", default: [], array: true
     t.string "default_order_statuses", default: [], array: true
+    t.integer "default_spare_parts_department_ids", default: [], array: true
+    t.string "default_spare_parts_statuses", default: [], array: true
+    t.integer "default_not_spare_parts_department_ids", default: [], array: true
+    t.string "default_not_spare_parts_statuses", default: [], array: true
+    t.integer "default_archive_department_ids", default: [], array: true
+    t.string "default_archive_statuses", default: [], array: true
     t.index ["user_id"], name: "index_user_settings_on_user_id"
   end
 


### PR DESCRIPTION
Extends the profile "Работа с заказами" tab with per-tab default branches and statuses for Запчасти, Не запчасти and Архив, on top of the existing global default. Storage is a set of array columns driven by a single UserSettings::SECTIONS constant, so migration, strong params, the form and the controller all iterate over one source of truth.

Default resolution is layered per request: section-specific value → global default → previous hardcoded behaviour. Archive is a deliberate exception — its status fallback is ['archive'] (skipping the global default), which also makes the previously inert Архив tab actually filter to archived orders.

UserSettings strips the blank option simple_form injects before each multi-select, so an untouched list stays [] (not [""]) and the layered fallback resolves correctly.