### PR TITLE
feat: add order call-reminders ("трубки") for orders

### DIFF
--- a/app/assets/stylesheets/service/feedbacks.css.scss
+++ b/app/assets/stylesheets/service/feedbacks.css.scss
@@ -11,6 +11,7 @@
 }
 
 .feedback_notification-section {
+  clear: both;
   text-align: center;
   font-weight: bold;
   color: #f00033;
@@ -57,6 +58,32 @@
       padding-right: 20px;
       color: #f00033;
     }
+  }
+}
+
+.order-feedback-desired {
+  font-size: 16px;
+  font-weight: bold;
+}
+
+.order-feedback-countdown {
+  margin-left: 8px;
+  padding: 1px 6px;
+  border-radius: 3px;
+  font-weight: bold;
+
+  &--ok {
+    color: #468847;
+  }
+
+  &--soon {
+    color: #ffffff;
+    background-color: #f89406;
+  }
+
+  &--overdue {
+    color: #ffffff;
+    background-color: #f00033;
   }
 }
 

--- a/app/helpers/order_feedbacks_helper.rb
+++ b/app/helpers/order_feedbacks_helper.rb
@@ -1,0 +1,33 @@
+module OrderFeedbacksHelper
+  # «осталось N дней» / «сегодня» / «просрочено на N дней» до желаемой даты,
+  # с цветовой подсветкой срочности.
+  def desired_date_countdown(desired_date)
+    return if desired_date.blank?
+
+    days = (desired_date - Date.current).to_i
+
+    if days > 0
+      text = "осталось #{days} #{days_word(days)}"
+      modifier = days <= 2 ? 'soon' : 'ok'
+    elsif days.zero?
+      text = 'сегодня'
+      modifier = 'soon'
+    else
+      text = "просрочено на #{days.abs} #{days_word(days)}"
+      modifier = 'overdue'
+    end
+
+    content_tag :span, text, class: "order-feedback-countdown order-feedback-countdown--#{modifier}"
+  end
+
+  def days_word(number)
+    remainder100 = number.abs % 100
+    return 'дней' if (11..14).cover?(remainder100)
+
+    case number.abs % 10
+    when 1 then 'день'
+    when 2, 3, 4 then 'дня'
+    else 'дней'
+    end
+  end
+end

--- a/app/views/order_feedbacks/_modal_form_content.html.haml
+++ b/app/views/order_feedbacks/_modal_form_content.html.haml
@@ -20,6 +20,15 @@
         - else
           = order.customer_presentation
 
+    .control-group.order-feedback-dates
+      %label.control-label Заказ создан
+      .controls= order.created_at&.strftime('%d.%m.%Y')
+    .control-group.order-feedback-dates
+      %label.control-label Желаемая дата
+      .controls
+        %strong.order-feedback-desired= order.desired_date ? order.desired_date.strftime('%d.%m.%Y') : '—'
+        = desired_date_countdown(order.desired_date)
+
     - if @order_feedback.log.present?
       .feedback-logs.well.well-small= raw @order_feedback.log
 


### PR DESCRIPTION
Extend the topbar phone-icon popover with an "Заказы" section above the existing "Сервис" one. Orders now get call-reminders (OrderFeedback), mirroring Service::Feedback.

Two reminders are scheduled per order from its dates: the midpoint between created_at and desired_date, and one day before desired_date. Orders without a desired_date get none. Reminders are created via an after_create hook and auto-deactivated when the order moves to done/issued/canceled/archive. A data migration backfills active orders with a future desired_date.

The reminder modal reuses the shared modal and shows the order's creation and desired dates with a coloured days-left countdown; it lets you leave a comment ("Перенести") or postpone ("Не дозвонился", +1h then next day). Access mirrors the service feedbacks policy (same abilities, scoped by the order's department/city).