### PR TITLE
feat: clarify client-card request section titles

### DIFF
--- a/config/locales/views/client_requests.ru.yml
+++ b/config/locales/views/client_requests.ru.yml
@@ -29,7 +29,7 @@ ru:
     unarchive:
       unarchived: Запрос возвращён из архива
     client_section:
-      title: Запросы клиента
+      title: Запросы на поиск оригинального чека
     client_request:
       usage: срок
       in_progress_btn: В работу

--- a/config/locales/views/device_unlock_requests.ru.yml
+++ b/config/locales/views/device_unlock_requests.ru.yml
@@ -53,7 +53,7 @@ ru:
     unarchive:
       unarchived: Запрос возвращён из архива
     client_section:
-      title: Запросы на разблокировку
+      title: Запросы на разблокировку устройства
     device_unlock_request:
       comment_placeholder: Добавить комментарий…
       comment_btn: Отправить


### PR DESCRIPTION
Both request kinds already render in the client card, but the receipt-search section read as the generic "Запросы клиента". Rename both section titles to the symmetric explicit "Запросы на …" form so the two kinds are unambiguously distinguished:
- receipt search  → "Запросы на поиск оригинального чека"
- device unlock   → "Запросы на разблокировку устройства"

Locale-only change; markup and logic untouched.