### PR TITLE
feat: add quick-plus button to topbar next to minus

### DIFF
--- a/app/assets/stylesheets/_inputs.css.scss
+++ b/app/assets/stylesheets/_inputs.css.scss
@@ -45,3 +45,13 @@ label.required {
   margin-right: 4px;
   color: red;
 }
+
+// Datepicker (my_date) внутри модального окна: глобальное правило
+// `.form-inline input { margin: 3px 0 }` (service_jobs.css.scss) сдвигает инпут вниз
+// относительно иконки-календаря `.add-on` в Bootstrap-2 `.input-prepend` — иконка и
+// поле перестают стыковаться. Обнуляем паразитный вертикальный отступ в контексте
+// модалки (не трогая service_jobs, где отступ задан намеренно).
+#modal_form .input-prepend input {
+  margin-top: 0;
+  margin-bottom: 0;
+}

--- a/app/helpers/merits_helper.rb
+++ b/app/helpers/merits_helper.rb
@@ -1,4 +1,8 @@
 module MeritsHelper
+  def header_merit_button
+    link_to glyph('plus-circle'), new_merit_path, remote: true, id: 'header-merit-link'
+  end
+
   def merit_recipients_collection
     User.active.staff.order(:name)
   end

--- a/app/views/shared/_topbar.html.erb
+++ b/app/views/shared/_topbar.html.erb
@@ -77,6 +77,7 @@
     <%= header_link_to_quack_control %>
     <%= header_link_to_notifications %>
     <%= header_fault_button if can? :create, Fault %>
+    <%= header_merit_button if can? :create, Merit %>
     <%#= header_link_for_device_returning %>
     <%= header_link_for_coffee %>
     <%= header_link_to_announce %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -190,6 +190,8 @@ Rails.application.routes.draw do
 
   resources :faults, only: %i[new create]
 
+  resources :merits, only: %i[new create]
+
   resources :karmas do
     post :group, on: :collection, defaults: {format: 'js'}
     post :addtogroup, on: :collection, defaults: {format: 'js'}


### PR DESCRIPTION
Mirror the existing header minus button (Fault) with a plus button (Merit) so seniors/managers can grant a plus to any employee without navigating into their profile. Add a top-level merits new/create route (parallel to faults) powering the topbar entry point; the create.js already no-ops the profile list update when it is absent. Reuses the existing Merit::Create operation, policy and recipient-select modal.