### PR TITLE
style: emphasize topbar reminder section headers

### DIFF
--- a/app/assets/stylesheets/service/feedbacks.css.scss
+++ b/app/assets/stylesheets/service/feedbacks.css.scss
@@ -12,10 +12,22 @@
 
 .feedback_notification-section {
   clear: both;
+  margin: 18px -14px 8px;
+  padding: 8px 14px;
   text-align: center;
+  font-size: 18px;
   font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
   color: #f00033;
-  padding: 6px 0 2px;
+  background-color: #e4e4e4;
+  border-top: 1px solid #cfcfcf;
+  border-bottom: 1px solid #cfcfcf;
+
+  &:first-child {
+    margin-top: -9px;
+    border-top: none;
+  }
 }
 
 #feedback_notification-list, #order_feedback_notification-list {


### PR DESCRIPTION
Make the "Заказы"/"Сервис" dividers in the phone-icon popover read as proper section headers: larger uppercased text on a grey band with top/bottom borders, and a top margin that visibly separates each section from the list above it. The previous #f5f5f5 fill was ~4% off white and blended into the popover background; #e4e4e4 plus borders gives a clear seam when scrolling through many reminders.