### PR TITLE
feat: notify superadmins of missing reception photos

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -88,6 +88,7 @@ class TasksController < ApplicationController
     params.require(:task)
           .permit(:code, :cost, :duration, :hidden, :location_code, :name,
                   :priority, :product_id, :role, :color, :tasks_positions,
+                  :require_reception_photo,
                   service_condition_ids: [], roles: [])
   end
 end

--- a/app/jobs/reception_photo_check_job.rb
+++ b/app/jobs/reception_photo_check_job.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# Одноразовая отложенная проверка «фото при приёмке».
+# Ставится ServiceJob#schedule_reception_photo_check ровно через час после того,
+# как у работы впервые появилась задача с флагом require_reception_photo и при
+# этом раздел «Фото при приёмке» пуст. Спустя час перепроверяем актуальное
+# состояние (за это время фото могли добавить, задачу — убрать, работу — удалить)
+# и, если фото так и нет, шлём in-app уведомление всем супер-админам.
+# Только in-app, без Telegram — как и другие «надзорные» уведомления супер-админам.
+# Образец — LocationOverstayCheckJob.
+class ReceptionPhotoCheckJob < ApplicationJob
+  KIND = 'reception_photo_missing'
+
+  queue_as :default
+
+  def perform(service_job_id)
+    service_job = ServiceJob.find_by(id: service_job_id)
+    return unless service_job
+    return unless service_job.reception_photo_required?
+    return unless service_job.reception_photo_absent?
+    return if Notification.exists?(referenceable: service_job, kind: KIND)
+
+    message = I18n.t('notifications.reception_photo_missing', ticket: service_job.ticket_number)
+    url = Rails.application.routes.url_helpers.service_job_path(service_job)
+
+    User.superadmins.active.find_each do |recipient|
+      notification = Notification.create!(
+        user: recipient,
+        referenceable: service_job,
+        message: message,
+        url: url,
+        kind: KIND
+      )
+      UserNotificationChannel.broadcast_to(notification.user, notification)
+    end
+  end
+end

--- a/app/models/service_job.rb
+++ b/app/models/service_job.rb
@@ -129,6 +129,7 @@ class ServiceJob < ApplicationRecord
   after_create :create_alert
   after_create :schedule_location_notifications
   after_commit :schedule_one_c_device_check, on: :create
+  after_commit :schedule_reception_photo_check, on: %i[create update]
   after_update :service_job_update_announce
   after_update :deduct_spare_parts
   after_update :clear_subscriptions_if_done_or_archived
@@ -535,6 +536,18 @@ kind: 'device_return', content: id.to_s)
     change
   end
 
+  # Есть ли среди задач приёмки хотя бы одна, помеченная как «требует фото».
+  # Публичный — используется и колбэком постановки, и ReceptionPhotoCheckJob
+  # при отложенной перепроверке.
+  def reception_photo_required?
+    device_tasks.joins(:task).where(tasks: { require_reception_photo: true }).exists?
+  end
+
+  # Раздел «Фото при приёмке» пуст (контейнера может не быть вовсе).
+  def reception_photo_absent?
+    photo_container.nil? || photo_container.reception_photos.blank?
+  end
+
   private
 
   # «Качели статуса»: закрывающая смена `in_progress → waiting` тем же юзером,
@@ -740,6 +753,19 @@ kind: 'device_return', content: id.to_s)
     location.parsed_overstay_thresholds.each do |days|
       LocationOverstayCheckJob.set(wait: days.days).perform_later(id, location.id, days)
     end
+  end
+
+  # Одноразовая проверка «есть ли фото при приёмке». Ставится через час, если
+  # среди задач работы есть помеченная (require_reception_photo) и фото приёмки
+  # ещё нет. Guard-таймстамп reception_photo_check_scheduled_at гарантирует, что
+  # даже при повторных редактированиях таймер заводится ровно один раз.
+  # Само уведомление шлёт ReceptionPhotoCheckJob, перепроверяя условие.
+  def schedule_reception_photo_check
+    return if reception_photo_check_scheduled_at.present?
+    return unless reception_photo_required? && reception_photo_absent?
+
+    update_column(:reception_photo_check_scheduled_at, Time.current)
+    ReceptionPhotoCheckJob.set(wait: 1.hour).perform_later(id)
   end
 
   def close_location_overstay_notifications_for_previous_location

--- a/app/views/tasks/_form.html.haml
+++ b/app/views/tasks/_form.html.haml
@@ -10,6 +10,7 @@
   = f.input :cost
   = f.input :color, as: :color
   = f.input :hidden
+  = f.input :require_reception_photo
 
   %fieldset
     %legend Пункты условий для заказ-наряда

--- a/config/locales/application.ru.yml
+++ b/config/locales/application.ru.yml
@@ -3,6 +3,7 @@ ru:
   notifications:
     warranty_overstay: 'Заказ №%{ticket} (купленное %{sold_date}) находится у нас более %{days} дней'
     location_overstay: 'Заказ №%{ticket} находится на локации «%{location}» более %{days} дней'
+    reception_photo_missing: 'По работе №%{ticket} отсутствуют фотографии при приёмке'
     queue_inactivity: 'Талон №%{ticket} в очереди «%{queue}» ждёт уже %{waited} мин. На смене %{total} сотр., активны только %{active}. Проверьте состояние очереди.'
     repair_attention: 'Работа №%{ticket} ждёт твоего внимания — приступаешь к ремонту?'
     repair_status_flip: '%{short_name} открыл работу №%{ticket} сменой статуса и вернул «в ожидании» за %{duration}'

--- a/config/locales/models.ru.yml
+++ b/config/locales/models.ru.yml
@@ -616,6 +616,7 @@ ru:
         location: 'Локация'
         location_code: 'Код локации'
         name: 'Название'
+        require_reception_photo: 'Требовать фото при приёмке'
         role: 'Роль'
         roles: 'Роли'
 

--- a/db/migrate/20260716172317_add_reception_photo_check_fields.rb
+++ b/db/migrate/20260716172317_add_reception_photo_check_fields.rb
@@ -1,0 +1,11 @@
+class AddReceptionPhotoCheckFields < ActiveRecord::Migration[5.1]
+  def change
+    # Флаг задачи: приёмка с такой задачей обязана иметь фото при приёмке.
+    add_column :tasks, :require_reception_photo, :boolean, default: false, null: false
+
+    # Guard-таймстамп: момент, когда для работы уже поставлена одноразовая
+    # проверка фото. Не NULL → повторные редактирования её не перезапускают
+    # (семантика «запустить один раз»).
+    add_column :service_jobs, :reception_photo_check_scheduled_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20260713192031) do
+ActiveRecord::Schema.define(version: 20260716172317) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1975,6 +1975,7 @@ ActiveRecord::Schema.define(version: 20260713192031) do
     t.bigint "repair_status_id"
     t.bigint "repair_pause_reason_id"
     t.datetime "repair_status_changed_at"
+    t.datetime "reception_photo_check_scheduled_at"
     t.index ["carrier_id"], name: "index_service_jobs_on_carrier_id"
     t.index ["case_color_id"], name: "index_service_jobs_on_case_color_id"
     t.index ["client_id"], name: "index_service_jobs_on_client_id"
@@ -2235,6 +2236,7 @@ ActiveRecord::Schema.define(version: 20260713192031) do
     t.string "color", default: ""
     t.integer "position", null: false
     t.string "roles", default: [], array: true
+    t.boolean "require_reception_photo", default: false, null: false
     t.index ["name"], name: "index_tasks_on_name"
     t.index ["product_id"], name: "index_tasks_on_product_id"
     t.index ["role"], name: "index_tasks_on_role"


### PR DESCRIPTION
Add a per-task flag "require reception photo" (checkbox on the task edit form). When a service job is created — or later edited — with any such task and the "Фото при приёмке" section is still empty, schedule a one-time check 1 hour later. If the photos are still missing, notify all active superadmins in-app (bell only, no Telegram) with a link to the job.

The check is enqueued via ReceptionPhotoCheckJob.set(wait: 1.hour), so no schedule.yml cron is needed. A guard column
service_jobs.reception_photo_check_scheduled_at ensures the timer is armed exactly once — subsequent edits do not restart it (start-once semantics). The job re-verifies the condition at run time (task still present, photos still absent) and is idempotent via a unique notification kind, mirroring LocationOverstayCheckJob.