### PR TITLE
feat: split repair top bar into in-progress and favorites

### DIFF
--- a/app/assets/stylesheets/service_job_subscriptions.css.scss
+++ b/app/assets/stylesheets/service_job_subscriptions.css.scss
@@ -1,9 +1,10 @@
 .subscriptions-bar {
   display: flex;
+  align-items: stretch;
   overflow-x: auto;
   background: #f5f5f5;
   padding: 10px 15px;
-  gap: 10px;
+  gap: 20px;
   border-bottom: 1px solid #ddd;
   box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 
@@ -24,6 +25,36 @@
   &::-webkit-scrollbar-thumb:hover {
     background: #555;
   }
+}
+
+.subscriptions-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex-shrink: 0;
+
+  // Vertical divider between the two labelled sections
+  & + & {
+    padding-left: 20px;
+    border-left: 1px solid #ddd;
+  }
+}
+
+.subscriptions-group__label {
+  font-size: 0.78em;
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: #999;
+}
+
+.subscriptions-group--in-progress .subscriptions-group__label {
+  color: #c0392b;
+}
+
+.subscriptions-group__list {
+  display: flex;
+  gap: 10px;
 }
 
 .subscription-block {
@@ -71,6 +102,14 @@
     color: #888;
     font-size: 0.85em;
     font-family: monospace;
+  }
+}
+
+.subscription-block--in-progress {
+  border-left: 3px solid #e74c3c;
+
+  .subscription-device {
+    color: #c0392b;
   }
 }
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -455,4 +455,31 @@ module ApplicationHelper
   def user_has_subscriptions?
     user_signed_in? && current_user.subscribed_service_jobs.any?
   end
+
+  # Devices the current user is actively repairing right now — the jobs they
+  # last moved into "in_progress" status. No role coupling: works for anyone
+  # who runs repairs, not only technicians. Memoized per request because the
+  # top-bar partial renders on every page from the layout.
+  def user_in_progress_service_jobs
+    return ServiceJob.none unless user_signed_in?
+
+    @user_in_progress_service_jobs ||=
+      ServiceJob.active_in_progress_for(current_user).includes(:client).to_a
+  end
+
+  # Starred/subscribed devices, minus any already shown in the "in progress"
+  # section so a device never appears twice in the top bar.
+  def user_favorite_service_jobs
+    return ServiceJob.none unless user_signed_in?
+
+    @user_favorite_service_jobs ||= begin
+      in_progress_ids = user_in_progress_service_jobs.map(&:id)
+      current_user.subscribed_service_jobs.includes(:client)
+                  .reject { |service_job| in_progress_ids.include?(service_job.id) }
+    end
+  end
+
+  def show_repair_top_bar?
+    user_signed_in? && (user_in_progress_service_jobs.any? || user_favorite_service_jobs.any?)
+  end
 end

--- a/app/views/shared/_user_subscriptions.html.haml
+++ b/app/views/shared/_user_subscriptions.html.haml
@@ -1,10 +1,28 @@
-- if user_signed_in? && current_user.subscribed_service_jobs.any?
+- if show_repair_top_bar?
   .subscriptions-bar
-    - current_user.subscribed_service_jobs.includes(:client).each do |service_job|
-      = link_to service_job_path(service_job), class: 'subscription-block' do
-        .subscription-device
-          = truncate(service_job.decorate.device_name, length: 20)
-        .subscription-client
-          = truncate(service_job.client&.presentation || '-', length: 20)
-        .subscription-ticket
-          = service_job.ticket_number
+    - in_progress_jobs = user_in_progress_service_jobs
+    - if in_progress_jobs.any?
+      .subscriptions-group.subscriptions-group--in-progress
+        .subscriptions-group__label= t('.in_progress_devices')
+        .subscriptions-group__list
+          - in_progress_jobs.each do |service_job|
+            = link_to service_job_path(service_job), class: 'subscription-block subscription-block--in-progress' do
+              .subscription-device
+                = truncate(service_job.decorate.device_name, length: 20)
+              .subscription-client
+                = truncate(service_job.client&.presentation || '-', length: 20)
+              .subscription-ticket
+                = service_job.ticket_number
+    - favorite_jobs = user_favorite_service_jobs
+    - if favorite_jobs.any?
+      .subscriptions-group.subscriptions-group--favorites
+        .subscriptions-group__label= t('.favorite_devices')
+        .subscriptions-group__list
+          - favorite_jobs.each do |service_job|
+            = link_to service_job_path(service_job), class: 'subscription-block' do
+              .subscription-device
+                = truncate(service_job.decorate.device_name, length: 20)
+              .subscription-client
+                = truncate(service_job.client&.presentation || '-', length: 20)
+              .subscription-ticket
+                = service_job.ticket_number

--- a/config/locales/views/shared.ru.yml
+++ b/config/locales/views/shared.ru.yml
@@ -89,3 +89,6 @@ ru:
       date: 'Дата'
       change: 'Изменение'
       created: 'Создание запроса'
+    user_subscriptions:
+      in_progress_devices: 'В процессе ремонта'
+      favorite_devices: 'Избранное'


### PR DESCRIPTION
The top strip previously showed only starred/subscribed devices with no label. Technicians asked to see the device they are currently repairing up there. Split the strip into two labelled sections:

- "В процессе ремонта": jobs the current user last moved into in_progress status (ServiceJob.active_in_progress_for), shown for anyone actively repairing — no technician-role coupling.
- "Избранное": the existing subscribed devices, minus any already shown in the in-progress section so a device never appears twice.

View + helper + CSS + locale only; no controller/model changes. Helpers memoize per request since the partial renders on every page via layout.