### PR TITLE
feat: prompt to switch department per today's schedule on login

### DIFF
--- a/app/controllers/users/departments_controller.rb
+++ b/app/controllers/users/departments_controller.rb
@@ -14,4 +14,17 @@ class Users::DepartmentsController < ApplicationController
     change_user_department current_user, department
     redirect_to root_path
   end
+
+  def schedule_prompt
+    @scheduled_department = current_user.scheduled_department_for_today
+    if @scheduled_department.blank? || @scheduled_department == current_user.department
+      redirect_to root_path
+    end
+  end
+
+  def schedule_change
+    department = current_user.scheduled_department_for_today
+    change_user_department current_user, department if department.present?
+    redirect_to root_path
+  end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -17,6 +17,11 @@ class Users::SessionsController < Devise::SessionsController
         user.save
       end
 
+      scheduled_department = user.scheduled_department_for_today
+      if scheduled_department.present? && scheduled_department != user.department
+        return redirect_to schedule_prompt_user_department_path
+      end
+
       if (location = after_sign_in_path_for(user))
         respond_with resource, location: location
         return

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -466,6 +466,17 @@ class User < ApplicationRecord
     @current_duty_day ||= duty_days.today.first
   end
 
+  # Подразделение, где сотрудник должен быть сегодня по расписанию смен.
+  # Учитываем только рабочие смены (у нерабочих department обнуляется).
+  def scheduled_department_for_today
+    ScheduleEntry
+      .where(user_id: id, date: Date.current)
+      .joins(:occupation_type)
+      .where(occupation_types: { counts_as_working: true })
+      .order(:id)
+      .first&.department
+  end
+
   def is_work_day?(day)
     day = day.respond_to?(:wday) ? day.wday : day.to_i
     if (schedule_day = schedule_days.find_by_day(day)).present?

--- a/app/views/users/departments/schedule_prompt.html.erb
+++ b/app/views/users/departments/schedule_prompt.html.erb
@@ -1,0 +1,9 @@
+<h1>Смена подразделения</h1>
+<p>
+  Согласно расписанию сегодня ты должен быть в подразделении
+  «<%= @scheduled_department.name %>». Поменять тебе подразделение?
+</p>
+<div class="form-actions">
+  <%= button_to 'Да', schedule_change_user_department_path, method: :patch, class: 'btn btn-primary' %>
+  <%= link_to 'Нет', root_path, class: 'btn' %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,7 +47,10 @@ Rails.application.routes.draw do
       post 'sign_in_technical', to: 'sessions#sign_in_technical'
       get 'technical_login', to: 'sessions#new_technical_login', as: 'new_technical_login'
     end
-    resource :departments, only: %i[edit update], as: :department
+    resource :departments, only: %i[edit update], as: :department do
+      get :schedule_prompt
+      patch :schedule_change
+    end
   end
 
   namespace :service do


### PR DESCRIPTION
After password sign-in, compare the user's current department with the one their shift schedule assigns for today (working ScheduleEntry). On mismatch, show a Yes/No interstitial offering to switch; Yes reuses change_user_department (which also moves the work location). Card login is left untouched. Scheduled department is recomputed on the prompt page rather than stashed in session, keeping the action idempotent.