### PR TITLE
feat: send personal Telegram DMs on Kanban card activity

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -112,6 +112,20 @@ class CommentsController < ApplicationController
       end
 
     end
+
+    notify_kanban_card_activity
+  end
+
+  # п.2/3 — personal Telegram DM to the card author and its managers, on top of
+  # the in-app bell above. Suppressed once the card sits in a "done" column.
+  def notify_kanban_card_activity
+    commentable = @comment.commentable
+    return unless commentable.is_a?(Kanban::Card)
+    return if commentable.column&.done?
+
+    KanbanCardActivityNotificationJob.perform_later(
+      'comment_added', commentable.id, current_user&.id, comment_id: @comment.id
+    )
   end
 
   def update_notifications

--- a/app/controllers/kanban/cards_controller.rb
+++ b/app/controllers/kanban/cards_controller.rb
@@ -26,6 +26,7 @@ module Kanban
           update_notifications if @notifications&.any?
           send_mail_to_managers
           send_telegram_to_chat
+          send_telegram_dm_to_board_managers
           format.html { redirect_to kanban_card_url(@card), notice: t('.created') }
           format.json { render :show, status: :created, location: @card }
         else
@@ -100,6 +101,10 @@ module Kanban
 
     def send_telegram_to_chat
       SendKanbanTelegramNotificationJob.perform_later(@card.id) if @card.board.telegram_chat.present?
+    end
+
+    def send_telegram_dm_to_board_managers
+      KanbanCardActivityNotificationJob.perform_later('card_created', @card.id, current_user&.id)
     end
   end
 end

--- a/app/jobs/kanban_card_activity_notification_job.rb
+++ b/app/jobs/kanban_card_activity_notification_job.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# Off-request delivery of Kanban card DMs. Building the absolute card URL needs
+# `routes.default_url_options[:host]` (production-only), so this runs async to
+# keep host/URL failures out of the request cycle — mirroring
+# SendKanbanTelegramNotificationJob.
+class KanbanCardActivityNotificationJob < ApplicationJob
+  queue_as :default
+
+  def perform(event, card_id, actor_id, opts = {})
+    card = Kanban::Card.unscoped.find_by(id: card_id)
+    return unless card
+
+    opts = opts.symbolize_keys
+    actor = User.find_by(id: actor_id)
+    notifier = Kanban::CardActivityNotifier.new(card, actor: actor)
+
+    case event.to_s
+    when 'card_created'
+      notifier.card_created
+    when 'card_moved'
+      notifier.card_moved(column(opts[:from_column_id]), column(opts[:to_column_id]))
+    when 'card_done'
+      notifier.card_done(column(opts[:to_column_id]))
+    when 'comment_added'
+      comment = Comment.find_by(id: opts[:comment_id])
+      notifier.comment_added(comment) if comment
+    end
+  end
+
+  private
+
+  def column(id)
+    id && Kanban::Column.find_by(id: id)
+  end
+end

--- a/app/models/kanban/card.rb
+++ b/app/models/kanban/card.rb
@@ -30,6 +30,8 @@ class Kanban::Card < ApplicationRecord
   audited
   has_associated_audits
 
+  after_update_commit :notify_column_change
+
   def url
     Rails.application.routes.url_helpers.kanban_card_path(self)
   end
@@ -48,5 +50,20 @@ class Kanban::Card < ApplicationRecord
 
   def unarchive!
     update!(archived: false)
+  end
+
+  private
+
+  # Fires on any update; only column moves are relevant. Covers both the
+  # drag-drop path (CardsController#update_card_columns) and the edit form —
+  # both funnel through a single `update(column_id:)`.
+  def notify_column_change
+    return unless previous_changes.key?('column_id')
+
+    old_id, new_id = previous_changes['column_id']
+    event = Kanban::Column.find_by(id: new_id)&.done? ? 'card_done' : 'card_moved'
+    KanbanCardActivityNotificationJob.perform_later(
+      event, id, User.current&.id, from_column_id: old_id, to_column_id: new_id
+    )
   end
 end

--- a/app/services/kanban/card_activity_notifier.rb
+++ b/app/services/kanban/card_activity_notifier.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+# Sends personal Telegram DMs about a Kanban card's lifecycle.
+#
+# Two recipient sets:
+#   * board managers  — notified once, when a card is created (they are
+#     "responsible on the board");
+#   * activity recipients (author + card managers) — notified about ongoing
+#     activity (moves, comments) until the card lands in a "done" column.
+#
+# The acting user is always excluded — you don't get pinged about your own
+# action. Delivery goes through NotifyEmployeeJob, which no-ops safely for
+# employees who haven't linked Telegram.
+module Kanban
+  class CardActivityNotifier
+    def initialize(card, actor: User.current)
+      @card = card
+      @actor = actor
+    end
+
+    # п.1 — новая карточка на доске → ответственным на доске
+    def card_created
+      notify(board_manager_recipients, new_card_text)
+    end
+
+    # п.2/3 — карточку перенесли между колонками (кроме «Готово»)
+    def card_moved(from_column, to_column)
+      notify(activity_recipients, moved_text(from_column, to_column))
+    end
+
+    # п.2/3 — карточку перенесли в колонку «Готово» (важное сообщение)
+    def card_done(to_column)
+      notify(activity_recipients, done_text(to_column))
+    end
+
+    # п.2/3 — новый комментарий к карточке
+    def comment_added(comment)
+      notify(activity_recipients, comment_text(comment))
+    end
+
+    private
+
+    attr_reader :card, :actor
+
+    def board_manager_recipients
+      without_actor(card.board.managers.to_a)
+    end
+
+    def activity_recipients
+      without_actor([card.author, *card.managers])
+    end
+
+    def without_actor(users)
+      users.compact.uniq.reject { |user| actor && user.id == actor.id }
+    end
+
+    # Runs inside KanbanCardActivityNotificationJob, so deliver synchronously —
+    # NotifyEmployee no-ops for employees who haven't linked Telegram.
+    def notify(recipients, text)
+      recipients.each { |user| NotifyEmployee.call(user: user, text: text) }
+    end
+
+    def new_card_text
+      <<~MSG.strip
+        На доске <b>#{esc(card.board_name)}</b>, где вы ответственный, новая карточка:
+
+        <b>#{esc(card.name)}</b>
+
+        #{link}
+      MSG
+    end
+
+    def moved_text(from_column, to_column)
+      <<~MSG.strip
+        Карточка <b>#{esc(card.name)}</b> на доске <b>#{esc(card.board_name)}</b> перемещена:
+        #{esc(from_column&.name)} → #{esc(to_column&.name)}
+
+        #{link}
+      MSG
+    end
+
+    def done_text(to_column)
+      <<~MSG.strip
+        ✅ Карточка <b>#{esc(card.name)}</b> на доске <b>#{esc(card.board_name)}</b> перенесена в «#{esc(to_column&.name)}».
+
+        #{link}
+      MSG
+    end
+
+    def comment_text(comment)
+      <<~MSG.strip
+        💬 Новый комментарий к карточке <b>#{esc(card.name)}</b> на доске <b>#{esc(card.board_name)}</b>:
+
+        #{esc(comment.content)}
+        — #{esc(comment.user&.short_name)}
+
+        #{link}
+      MSG
+    end
+
+    def link
+      %(<a href="#{card_url}">Перейти на карточку</a>)
+    end
+
+    def card_url
+      Rails.application.routes.url_helpers.kanban_card_url(card)
+    end
+
+    def esc(text)
+      CGI.escapeHTML(text.to_s)
+    end
+  end
+end


### PR DESCRIPTION
Extend the employee-DM bot with three card notifications:
1. Card created -> DM to every board manager (in addition to the existing group-chat message), so people responsible on a board learn about new cards personally. 2/3. Card moved between columns and new comments -> DM to the card
   author and its per-card managers, until the card lands in a "done"
   column. Moving into a done column sends a distinct "готово" message;
   afterwards further activity is suppressed.

The acting user is always excluded (no self-pings) and recipients are deduped, so a manager who is also the author gets a single message.

Column moves are detected in Kanban::Card#after_update_commit via previous_changes[:column_id], which covers both the drag-drop path (update_card_columns) and the edit form through a single hook.

Delivery is centralized in Kanban::CardActivityNotifier and dispatched off-request through KanbanCardActivityNotificationJob — building the absolute card URL needs routes.default_url_options[:host] (production only), so keeping it async isolates host/URL failures from the card create/move/comment request, mirroring SendKanbanTelegramNotificationJob.

The existing in-app bell notification for card comments is left intact.