### PR TITLE
feat: add white-card and background-image options to kanban boards

### DIFF
--- a/app/assets/javascripts/kanban.js.coffee
+++ b/app/assets/javascripts/kanban.js.coffee
@@ -57,12 +57,25 @@ jQuery ->
     $board = $(this)
     backgroundColor = $board.data('background') || '#ffffff'
     $board.css 'background-color', backgroundColor
+    bgImage = $board.data('bg-image')
+    if bgImage && bgImage.toString().trim() != ''
+      $board.css
+        'background-image': "url(#{bgImage})"
+        'background-size': 'cover'
+        'background-position': 'center'
+        'background-repeat': 'no-repeat'
     fontColor = $board.data('font-color')
     if fontColor && fontColor.trim() != ''
       $board.find('.kanban-card a').css 'color', fontColor
     fontSize = $board.data('font-size')
     if fontSize && fontSize.toString().trim() != ''
       $board.find('.kanban-card a').css 'font-size', "#{fontSize}px"
+    # White-card mode is a readable "package": white background + black text.
+    # Applied last so it wins over card_font_color set above.
+    whiteCards = $board.data('white-cards')
+    if whiteCards == true || whiteCards == 'true'
+      $board.find('.kanban-card').css 'background-color', '#ffffff'
+      $board.find('.kanban-card a').css 'color', '#000000'
 
   $('.kanban-card-content').each ->
     $card = $(this)

--- a/app/controllers/kanban/boards_controller.rb
+++ b/app/controllers/kanban/boards_controller.rb
@@ -102,6 +102,7 @@ module Kanban
 
     def board_params
       params.require(:kanban_board).permit(:name, :background, :sort_order, :open_background_color, :card_font_color, :outer_annotation, :inner_annotation, :open_card_font_size, :card_font_size,
+                                           :card_white_background, :background_image, :background_image_cache, :remove_background_image,
                                            :telegram_chat_id, manager_ids: [], allowed_user_ids: [], auto_add_department_ids: [])
     end
   end

--- a/app/models/kanban/board.rb
+++ b/app/models/kanban/board.rb
@@ -1,4 +1,6 @@
 class Kanban::Board < ApplicationRecord
+  mount_uploader :background_image, KanbanBackgroundUploader
+
   scope :active, -> { where(archived: false) }
   scope :archived, -> { where(archived: true) }
 

--- a/app/uploaders/kanban_background_uploader.rb
+++ b/app/uploaders/kanban_background_uploader.rb
@@ -1,0 +1,14 @@
+class KanbanBackgroundUploader < CarrierWave::Uploader::Base
+  include CarrierWave::MiniMagick
+
+  storage :fog
+
+  # Cap the stored image so a huge upload doesn't bloat storage or slow the
+  # board page — the background is displayed with `background-size: cover`,
+  # so anything beyond full-HD adds weight without visible gain.
+  process resize_to_limit: [1920, 1920]
+
+  def extension_allowlist
+    %w(jpg jpeg gif png webp)
+  end
+end

--- a/app/views/kanban/boards/_form.html.erb
+++ b/app/views/kanban/boards/_form.html.erb
@@ -5,6 +5,19 @@
   <%= form.input :card_font_color, as: :color %>
   <%= form.input :card_font_size %>
   <%= form.input :open_card_font_size %>
+  <%= form.input :card_white_background, as: :boolean,
+        label: 'Белый фон карточек (чёрный текст)',
+        hint: 'Карточки станут белыми с чёрным текстом — читаемо поверх цветного фона или картинки.' %>
+  <%= form.input :background_image, as: :file,
+        label: 'Картинка на фон доски',
+        hint: 'Заполняет фон доски целиком (может обрезаться по краям). Перекрывает цвет фона.' %>
+  <%= form.hidden_field :background_image_cache %>
+  <% if board.background_image? %>
+    <div class="control-group kanban-background-preview">
+      <%= image_tag board.background_image.file.authenticated_url(expires_in: 600), style: 'max-height: 80px;' %>
+      <%= form.input :remove_background_image, as: :boolean, label: 'Удалить картинку' %>
+    </div>
+  <% end %>
   <%= form.input :outer_annotation %>
   <%= form.input :inner_annotation %>
   <%= form.association :telegram_chat,

--- a/app/views/kanban/boards/show.html.erb
+++ b/app/views/kanban/boards/show.html.erb
@@ -1,7 +1,9 @@
 <div class="kanban-board"
-     data-background=<%= @board.open_background_color %>
-     data-font-color=<%= @board.card_font_color %>
-     data-font-size=<%= @board.card_font_size %>
+     data-background="<%= @board.open_background_color %>"
+     data-font-color="<%= @board.card_font_color %>"
+     data-font-size="<%= @board.card_font_size %>"
+     data-white-cards="<%= @board.card_white_background %>"
+     data-bg-image="<%= @board.background_image? ? @board.background_image.file.authenticated_url(expires_in: 3600) : '' %>"
 >
   <div class="page-header">
     <h2>

--- a/db/migrate/20260723173150_add_appearance_to_kanban_boards.rb
+++ b/db/migrate/20260723173150_add_appearance_to_kanban_boards.rb
@@ -1,0 +1,6 @@
+class AddAppearanceToKanbanBoards < ActiveRecord::Migration[5.1]
+  def change
+    add_column :kanban_boards, :card_white_background, :boolean, default: false, null: false
+    add_column :kanban_boards, :background_image, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20260716172317) do
+ActiveRecord::Schema.define(version: 20260723173150) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -879,6 +879,8 @@ ActiveRecord::Schema.define(version: 20260716172317) do
     t.integer "auto_add_department_ids", default: [], array: true
     t.bigint "telegram_chat_id"
     t.boolean "archived", default: false, null: false
+    t.boolean "card_white_background", default: false, null: false
+    t.string "background_image"
     t.index ["allowed_user_ids"], name: "index_kanban_boards_on_allowed_user_ids"
     t.index ["archived"], name: "index_kanban_boards_on_archived"
     t.index ["auto_add_department_ids"], name: "index_kanban_boards_on_auto_add_department_ids", using: :gin


### PR DESCRIPTION
Two per-board appearance settings addressing readability of cards over the colored board background:

- card_white_background (boolean): renders cards with a white background and forced black text — a readable "package" applied last in the JS so it overrides card_font_color.
- background_image (CarrierWave/fog uploader): a board background image shown with `background-size: cover`, overriding open_background_color. Includes a remove checkbox and cache field on the edit form.

Both hook into the existing data-attribute → jQuery styling pipeline in kanban.js.coffee. Also quotes the board's ERB-interpolated data attributes: an unquoted empty `data-font-size=` was swallowing the following attribute during HTML parsing. Migration adds both columns.