### PR TITLE
feat: color plus/minus employee dropdowns by department

### DIFF
--- a/app/assets/javascripts/custom_select.js.coffee
+++ b/app/assets/javascripts/custom_select.js.coffee
@@ -1,5 +1,28 @@
-$ ->
-  $('.custom-select-wrapper').each ->
+# Picks black or white text for a given background so options stay readable
+# on dark department colors. Returns '' for a blank color (leave CSS default).
+contrastColor = (hex) ->
+  return '' unless hex
+  c = hex.toString().replace('#', '')
+  c = c.split('').map((ch) -> ch + ch).join('') if c.length == 3
+  return '' unless c.length == 6
+  r = parseInt(c.substr(0, 2), 16)
+  g = parseInt(c.substr(2, 2), 16)
+  b = parseInt(c.substr(4, 2), 16)
+  luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255
+  if luminance > 0.6 then '#000000' else '#ffffff'
+
+# Applies a background color plus a contrasting text color to an element.
+paintOption = ($el, color) ->
+  $el.css
+    'background-color': color or ''
+    'color': contrastColor(color)
+
+# Syncs each custom-select trigger (text + color) with its hidden field's
+# current value. Exposed globally so AJAX-injected content (e.g. modal forms)
+# can re-init after render — the document-ready pass below only covers the
+# markup present on first page load.
+window.initCustomSelects = (context = document) ->
+  $('.custom-select-wrapper', context).each ->
     $wrapper = $(this)
     $hiddenInput = $wrapper.find('input[type="hidden"]')
     selectedValue = $hiddenInput.val()
@@ -15,10 +38,13 @@ $ ->
 
         $trigger = $wrapper.find('.custom-select__trigger')
         $span = $trigger.find('span')
-        $trigger.css('background-color', optionColor)
+        paintOption($trigger, optionColor)
         $span.text(optionText)
       else
         $option.removeClass('selected')
+
+$ ->
+  initCustomSelects()
 
   $(document).on 'click', '.custom-select__trigger', (event) ->
     event.stopPropagation()
@@ -29,8 +55,7 @@ $ ->
     if select.hasClass('open')
       select.find('.custom-option.selected').addClass('hover')
       select.find('.custom-option').each ->
-        color = $(this).data('color')
-        $(this).css('background-color', color) if color
+        paintOption($(this), $(this).data('color'))
     else
       select.find('.custom-option').removeClass('hover')
 
@@ -44,7 +69,7 @@ $ ->
     selectedColor = $(this).data('color')
 
     trigger.find('span').html($(this).html())
-    trigger.css('background-color', selectedColor)
+    paintOption(trigger, selectedColor)
     select.find('.custom-option').removeClass('selected')
     hiddenInput
       .val(selectedValue)

--- a/app/assets/stylesheets/custom_select.css.scss
+++ b/app/assets/stylesheets/custom_select.css.scss
@@ -4,7 +4,11 @@
   font-weight: normal;
 }
 
-.custom_select {
+// Scoped under the wrapper: SimpleForm also stamps the input-type class
+// `custom_select` onto the surrounding .control-group, so an unscoped
+// `.custom_select` rule would turn the whole form row into a flex column
+// and break Bootstrap's horizontal label/controls layout.
+.custom-select-wrapper .custom_select {
   position: relative;
   display: flex;
   flex-direction: column;
@@ -39,7 +43,7 @@
   }
 }
 
-.custom_select.open .custom-options {
+.custom-select-wrapper .custom_select.open .custom-options {
   opacity: 1;
   visibility: visible;
   pointer-events: all;

--- a/app/inputs/custom_select_input.rb
+++ b/app/inputs/custom_select_input.rb
@@ -45,15 +45,22 @@ class CustomSelectInput < SimpleForm::Inputs::Base
   end
 
   def item_label(item)
+    method = @options[:label_method]
+    return item.public_send(method).to_s if method
+
     item.try(:name) || item.to_s
   end
 
   def item_value(item)
+    method = @options[:value_method]
+    return item.public_send(method).to_s if method
+
     item.try(:id) || item.to_s
   end
 
   def item_color(item)
-    item.try(:color) || ''
+    method = @options[:color_method] || :color
+    item.try(method) || ''
   end
 
   def placeholder_text

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -524,6 +524,13 @@ class User < ApplicationRecord
     color.blank? ? '#ffffff' : color
   end
 
+  # Department's color (delegated to its city). Used to tint employee options
+  # in plus/minus dropdowns so same-named staff from different departments
+  # are told apart. Not the personal `color` column above.
+  def department_color
+    department&.color
+  end
+
   def upcoming_birthday?
     if birthday.present?
       today = Date.current

--- a/app/views/faults/_modal_form_content.html.haml
+++ b/app/views/faults/_modal_form_content.html.haml
@@ -6,7 +6,7 @@
   .modal-body
     - if @form.errors.any?
       .alert.alert-error= @form.errors.full_messages.join('. ')
-    = f.input :causer_id, collection: fault_causers_collection, label_method: :short_name, as: :select, label: Fault.human_attribute_name(:causer)
+    = f.input :causer_id, collection: fault_causers_collection, label_method: :short_name, color_method: :department_color, as: :custom_select, prompt: t('.select_employee'), label: Fault.human_attribute_name(:causer)
     = f.input :date, as: :my_date
     = f.input :kind_id, collection: fault_kinds_collection, as: :select, label: Fault.human_attribute_name(:kind), input_html: {data: fault_kinds_data}, hint: (@form.description || '')
     = f.input :penalty, wrapper_html: {class: 'hidden'}

--- a/app/views/merits/_modal_form_content.html.haml
+++ b/app/views/merits/_modal_form_content.html.haml
@@ -6,7 +6,7 @@
   .modal-body
     - if @form.errors.any?
       .alert.alert-error= @form.errors.full_messages.join('. ')
-    = f.input :recipient_id, collection: merit_recipients_collection, label_method: :short_name, as: :select, label: Merit.human_attribute_name(:recipient)
+    = f.input :recipient_id, collection: merit_recipients_collection, label_method: :short_name, color_method: :department_color, as: :custom_select, prompt: t('.select_employee'), label: Merit.human_attribute_name(:recipient)
     = f.input :date, as: :my_date
     = f.input :comment, as: :text
     = f.input :issued_by_id, as: :hidden, input_html: { value: current_user.id }

--- a/app/views/shared/show_modal_form.js.erb
+++ b/app/views/shared/show_modal_form.js.erb
@@ -14,3 +14,5 @@ $("#modal_form:hidden").modal('show');
 
 $("a[rel~=popover], .has-popover").popover();
 $("a[rel~=tooltip], .has-tooltip").tooltip();
+
+if (window.initCustomSelects) initCustomSelects('#modal_form');

--- a/config/locales/views/faults.ru.yml
+++ b/config/locales/views/faults.ru.yml
@@ -1,5 +1,7 @@
 ru:
   faults:
+    modal_form_content:
+      select_employee: 'Выберите сотрудника'
     index:
       title: 'Минусы'
     new:

--- a/config/locales/views/merits.ru.yml
+++ b/config/locales/views/merits.ru.yml
@@ -1,5 +1,7 @@
 ru:
   merits:
+    modal_form_content:
+      select_employee: 'Выберите сотрудника'
     index:
       title: 'Плюсы'
     new:


### PR DESCRIPTION
Reuse the custom_select component (already used for device_tasks on the service_job form) in the Merit (plus) and Fault (minus) modals so each employee option is tinted with its department's color, telling apart same-named staff from different departments (e.g. two Dmitry Popovs).

- custom_select_input: add optional label_method/color_method options (backward compatible; existing device_task/achievement usages unchanged)
- User#department_color delegates to department.color (city color), not the personal `color` column
- point recipient_id/causer_id selects at as: :custom_select
- custom_select.js: expose initCustomSelects(context), called from show_modal_form.js so AJAX modals sync trigger text/color (incl. after a validation-failure re-render); pick black/white option text by background luminance so dark department colors stay readable
- scope the generic `.custom_select` CSS rules under .custom-select-wrapper: SimpleForm stamps that class onto the .control-group too, which was turning the modal row into a flex column and misaligning the field