### PR TITLE
feat: add repair-service mark reference and expose it via API

### DIFF
--- a/app/api/entities/repair_service_entity.rb
+++ b/app/api/entities/repair_service_entity.rb
@@ -9,6 +9,10 @@ class Entities::RepairServiceEntity < Grape::Entity
   expose :spare_parts do |repair_service, options|
     get_cached_spare_parts(repair_service, options[:departments])
   end
+  expose :mark do |repair_service, options|
+    mark = repair_service.repair_service_mark
+    { id: mark.id, name: mark.name } if mark
+  end
 
   private
 

--- a/app/api/repair_api.rb
+++ b/app/api/repair_api.rb
@@ -14,7 +14,7 @@ class RepairApi < Grape::API
     if params[:group_id].present?
       repair_group = RepairGroup.find(params[:group_id])
       repair_groups = repair_group.children
-      repair_services = repair_group.repair_services.includes(:prices, :spare_parts, :store_items)
+      repair_services = repair_group.repair_services.includes(:prices, :spare_parts, :store_items, :repair_service_mark)
       present :repair_services, repair_services, with: Entities::RepairServiceEntity, departments: departments
     else
       repair_groups = RepairGroup.roots

--- a/app/controllers/repair_services_controller.rb
+++ b/app/controllers/repair_services_controller.rb
@@ -226,7 +226,8 @@ class RepairServicesController < ApplicationController
   def repair_service_params
     params.require(:repair_service).permit(
       :name, :client_info, :repair_group_id, :is_positive_price, :difficult, :is_body_repair, :is_popular,
-      :has_range_prices, :repair_time, :special_marks, :time_standard, :time_standard_from, :time_standard_to, repair_cause_ids: [],
+      :has_range_prices, :repair_time, :special_marks, :time_standard, :time_standard_from, :time_standard_to,
+      :repair_service_mark_id, repair_cause_ids: [],
       spare_parts_attributes: [:id, :_destroy, :quantity, :warranty_term, :product_id],
       prices_attributes: [:id, :value, :department_id, :is_range_price, :value_from, :value_to]
     )

--- a/app/models/repair_service.rb
+++ b/app/models/repair_service.rb
@@ -19,6 +19,7 @@ class RepairService < ApplicationRecord
   scope :not_archived, -> { where(archived: false) }
 
   belongs_to :repair_group, optional: true
+  belongs_to :repair_service_mark, optional: true
   has_many :spare_parts, dependent: :destroy
   has_many :store_items, through: :spare_parts
   has_many :prices, class_name: 'RepairPrice', inverse_of: :repair_service, dependent: :destroy

--- a/app/models/repair_service_mark.rb
+++ b/app/models/repair_service_mark.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class RepairServiceMark < ApplicationRecord
+  NOTIFICATION_CODE = 'notification'
+
+  default_scope { order(:position, :id) }
+
+  has_many :repair_services, dependent: :nullify
+
+  validates :name, presence: true
+
+  def self.notification
+    find_by(code: NOTIFICATION_CODE)
+  end
+end

--- a/app/views/repair_services/form.html.haml
+++ b/app/views/repair_services/form.html.haml
@@ -33,6 +33,14 @@
   = f.input :is_body_repair
   = f.input :is_popular
   = f.input :special_marks
+  - if (notification_mark = RepairServiceMark.notification)
+    .control-group
+      %label.control-label Отметки
+      .controls
+        = hidden_field_tag 'repair_service[repair_service_mark_id]', '', id: nil
+        %label.checkbox.inline
+          = check_box_tag 'repair_service[repair_service_mark_id]', notification_mark.id, f.object.repair_service_mark_id == notification_mark.id, id: 'repair_service_notification_mark'
+          = notification_mark.title.presence || notification_mark.name
   = f.input :repair_cause_ids,
     collection: RepairCauseGroup.all,
     as: :grouped_select,

--- a/db/data/20260803085536_seed_notification_repair_service_mark.rb
+++ b/db/data/20260803085536_seed_notification_repair_service_mark.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class SeedNotificationRepairServiceMark < ActiveRecord::Migration[5.1]
+  def up
+    mark = RepairServiceMark.find_or_initialize_by(code: 'notification')
+    mark.name = 'с уведомлением'
+    mark.title = '1. Что такое с уведомлением?'
+    mark.position ||= 1
+    mark.save!
+  end
+
+  def down
+    RepairServiceMark.where(code: 'notification').delete_all
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20260731150210)
+DataMigrate::Data.define(version: 20260803085536)

--- a/db/migrate/20260803085508_create_repair_service_marks.rb
+++ b/db/migrate/20260803085508_create_repair_service_marks.rb
@@ -1,0 +1,13 @@
+class CreateRepairServiceMarks < ActiveRecord::Migration[5.1]
+  def change
+    create_table :repair_service_marks do |t|
+      t.string :name, null: false
+      t.string :title
+      t.string :code
+      t.integer :position
+
+      t.timestamps
+    end
+    add_index :repair_service_marks, :code, unique: true
+  end
+end

--- a/db/migrate/20260803085513_add_repair_service_mark_to_repair_services.rb
+++ b/db/migrate/20260803085513_add_repair_service_mark_to_repair_services.rb
@@ -1,0 +1,5 @@
+class AddRepairServiceMarkToRepairServices < ActiveRecord::Migration[5.1]
+  def change
+    add_reference :repair_services, :repair_service_mark, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20260801070619) do
+ActiveRecord::Schema.define(version: 20260803085513) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1587,6 +1587,16 @@ ActiveRecord::Schema.define(version: 20260801070619) do
     t.index ["repair_service_id"], name: "index_repair_prices_on_repair_service_id"
   end
 
+  create_table "repair_service_marks", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "title"
+    t.string "code"
+    t.integer "position"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["code"], name: "index_repair_service_marks_on_code", unique: true
+  end
+
   create_table "repair_services", id: :serial, force: :cascade do |t|
     t.integer "repair_group_id"
     t.string "name", limit: 255
@@ -1604,7 +1614,9 @@ ActiveRecord::Schema.define(version: 20260801070619) do
     t.integer "time_standard_from"
     t.integer "time_standard_to"
     t.boolean "is_popular", default: false, null: false
+    t.bigint "repair_service_mark_id"
     t.index ["repair_group_id"], name: "index_repair_services_on_repair_group_id"
+    t.index ["repair_service_mark_id"], name: "index_repair_services_on_repair_service_mark_id"
   end
 
   create_table "repair_status_changes", force: :cascade do |t|
@@ -2727,6 +2739,7 @@ ActiveRecord::Schema.define(version: 20260801070619) do
   add_foreign_key "repair_attention_markers", "users", column: "processed_by_id"
   add_foreign_key "repair_prices", "departments"
   add_foreign_key "repair_prices", "repair_services"
+  add_foreign_key "repair_services", "repair_service_marks"
   add_foreign_key "repair_status_changes", "repair_pause_reasons"
   add_foreign_key "repair_status_changes", "repair_statuses", column: "from_status_id"
   add_foreign_key "repair_status_changes", "repair_statuses", column: "to_status_id"


### PR DESCRIPTION
Introduce RepairServiceMark reference table so repair services can carry a mark shown to external API consumers. Start with a single mark, "с уведомлением" (code: notification), rendered as a checkbox on the repair-service form and seeded via a data migration so it exists on production automatically.

The service holds one mark via a repair_service_mark_id FK (optional). RepairServiceEntity exposes it as { id, name } under the "mark" key (null when unset); the API query eager-loads the association to avoid N+1. When more marks are added the FK makes them mutually exclusive — switching to many-per-service would mean moving to a HABTM join.